### PR TITLE
'source' param included in registration and reportback requests

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/data/User.java
+++ b/app/src/main/java/org/dosomething/letsdothis/data/User.java
@@ -32,6 +32,8 @@ public class User
     @DatabaseField
     public String avatarPath;
 
+    public final String source = "android";
+
     public User()
     {
     }
@@ -83,27 +85,4 @@ public class User
         String finalJson = json.replace("\\", "");
         return new TypedByteArray("application/json", finalJson.getBytes("UTF-8"));
     }
-
-
-  /* Optional */
-    //    birthdate: Date,
-    //    addr_street1 : String
-    //    addr_street2 : String
-    //    addr_city : String
-    //    addr_state : String
-    //    addr_zip : String
-    //    country : String - two character country code
-    //    agg_id: Int
-    //    cgg_id: Int
-    //    drupal_id: Int
-    //    race: String
-    //    religion: String
-    //    college_name: String
-    //    degree_type: String
-    //    major_name: String
-    //    hs_gradyear: String
-    //    hs_name: String
-    //    sat_math: Int
-    //    sat_verbal: Int
-    //    sat_writing: Int
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/RequestCampaignSignup.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/RequestCampaignSignup.java
@@ -4,7 +4,7 @@ package org.dosomething.letsdothis.network.models;
  */
 public class RequestCampaignSignup
 {
-    public String source = "android";
+    public final String source = "android";
     public Integer group;
 
     public RequestCampaignSignup(Integer groupId)

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/RequestReportback.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/RequestReportback.java
@@ -9,4 +9,5 @@ public class RequestReportback
     public String file;
     public String why_participated;
     public String caption;
+    public final String source = "android";
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseAvatar.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseAvatar.java
@@ -8,6 +8,6 @@ public class ResponseAvatar
 
     public static class Wrapper
     {
-        public String url;
+        public String avatar;
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/ReportbackUploadTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/ReportbackUploadTask.java
@@ -37,6 +37,7 @@ public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
     private ReportbackUploadTask(RequestReportback req, int campaignId, String filePath)
     {
         this.req = req;
+        this.req.why_participated = "(Not provided by reportback submissions from the Android app)";
         this.campaignId = campaignId;
         this.filePath = filePath;
     }
@@ -45,7 +46,6 @@ public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
     protected void run(Context context) throws Throwable
     {
         req.file = base64Encode(filePath);
-        req.why_participated = "Doing something!";
         String sessionToken = AppPrefs.getInstance(context).getSessionToken();
         ResponseSubmitReportBack response = NetworkHelper.getNorthstarAPIService()
                 .submitReportback(sessionToken, req, campaignId);

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
@@ -44,7 +44,7 @@ public class UploadAvatarTask extends Task
         TypedFile typedFile = new TypedFile("multipart/form-data", file);
         ResponseAvatar response = NetworkHelper.getNorthstarAPIService()
                 .uploadAvatar(userId, typedFile);
-        user.avatarPath = response.data.url;
+        user.avatarPath = response.data.avatar;
         userDao.createOrUpdate(user);
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
@@ -182,7 +182,7 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
             if(requestCode == SELECT_PICTURE)
             {
                 final boolean isCamera;
-                if(data.getData() == null)
+                if(data == null || data.getData() == null)
                 {
                     isCamera = true;
                 }


### PR DESCRIPTION
#### What's this PR do?
- `"android"` is included as the `source` on user registration, signup, and reportback requests. We were already doing it for signups and just needed to add to the models for requests sent on registration and reportback.
- Avatar wrapper and crash fixes: ResponseAvatar, UploadAvatarTask, SettingsFragment

#### How was this tested?
Through the app, registered a new user on staging. Signed up for and submitted a reportback for a campaign. Verified relevant `source` fields were populated on the staging db.

#### What are the relevant tickets?
Closes #73