### PR TITLE
Login/Reg error styling + source and country in request data

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/data/User.java
+++ b/app/src/main/java/org/dosomething/letsdothis/data/User.java
@@ -25,13 +25,12 @@ public class User
     public String last_name;
     @DatabaseField
     public String birthdate;
-
-    //DON'T STORE PASSWORD IN DATABASE
-    public String password;
-
     @DatabaseField
     public String avatarPath;
 
+    // Fields not saved in the database
+    public String country;
+    public String password;
     public String source;
 
     public User()
@@ -54,29 +53,26 @@ public class User
     public static TypedInput getJsonTypedInput(User user) throws Throwable
     {
         JSONObject jsonObject = new JSONObject();
-        if(user.first_name != null && ! user.first_name.isEmpty())
-        {
+        if (user.first_name != null && !user.first_name.isEmpty()) {
             jsonObject.put("first_name", user.first_name);
         }
-        if(user.last_name != null && ! user.last_name.isEmpty())
-        {
+        if (user.last_name != null && !user.last_name.isEmpty()) {
             jsonObject.put("last_name", user.last_name);
         }
-        if(user.email != null && ! user.email.isEmpty())
-        {
+        if (user.email != null && !user.email.isEmpty()) {
             jsonObject.put("email", user.email);
         }
-        if(user.mobile != null && ! user.mobile.isEmpty())
-        {
+        if (user.mobile != null && !user.mobile.isEmpty()) {
             jsonObject.put("mobile", user.mobile);
         }
-        if(user.password != null && ! user.password.isEmpty())
-        {
+        if (user.password != null && !user.password.isEmpty()) {
             jsonObject.put("password", user.password);
         }
-        if(user.birthdate != null && ! user.birthdate.isEmpty())
-        {
+        if (user.birthdate != null && !user.birthdate.isEmpty()) {
             jsonObject.put("birthdate", user.birthdate);
+        }
+        if (user.country != null && !user.country.isEmpty()) {
+            jsonObject.put("country", user.country);
         }
 
         String json = jsonObject.toString();

--- a/app/src/main/java/org/dosomething/letsdothis/data/User.java
+++ b/app/src/main/java/org/dosomething/letsdothis/data/User.java
@@ -32,7 +32,7 @@ public class User
     @DatabaseField
     public String avatarPath;
 
-    public final String source = "android";
+    public String source;
 
     public User()
     {

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseLogin.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseLogin.java
@@ -18,14 +18,7 @@ public class ResponseLogin
         public String first_name;
         public String last_name;
         public String birthday;
-        public String avatar;
+        public String country;
+        public String photo;
     }
-
-
-    //    email: "cooldude6",
-    //    phone: "555-555-5555",
-    //    created_at: "2011-11-07T20:58:34.448Z",
-    //    updated_at: "2011-11-07T20:58:34.448Z",
-    //    _id: "g7y9tkhB7O",
-    //    session_token: "pnktnjyb996sj4p156gjtp4im"
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseRegister.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseRegister.java
@@ -10,6 +10,7 @@ public class ResponseRegister
     {
         public String  _id;
         public String  email;
+        public String  mobile;
         public String  birthday;
         public String  first_name;
         public String  last_name;

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseUserUpdate.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseUserUpdate.java
@@ -1,28 +1,14 @@
 package org.dosomething.letsdothis.network.models;
+
+import org.dosomething.letsdothis.data.User;
+
 /**
  * Created by toidiu on 4/16/15.
  */
-public class ResponseUserUpdate
-{
+public class ResponseUserUpdate {
     public Wrapper data;
 
-    private class Wrapper
-    {
-        public DateWrapper updated_at;
-
-        private class DateWrapper
-        {
-            public String date;
-        }
+    private class Wrapper {
+        public User user;
     }
-
-//    {
-//        "data": {
-//        "updated_at": {
-//            "date": "2015-05-19 19:03:21.000000",
-//                    "timezone_type": 3,
-//                    "timezone": "UTC"
-//        }
-//    }
-
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
@@ -42,18 +42,30 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
                                              new ParseInstallationRequest(parseInstallation));
     }
 
+    /**
+     * Using the configured country instead of something provided by the LocationManager. This should
+     * be fine in a large majority of cases. If we find we need to get more refined with our location,
+     * then we can revisit this.
+     *
+     * @param context
+     * @return String country code
+     */
+    protected String getCountryCode(Context context) {
+        return context.getResources().getConfiguration().locale.getCountry();
+    }
+
     @Override
-    protected void run(Context context) throws Throwable
-    {
-        if(mPhoneEmail == null)
-        {
+    protected void run(Context context) throws Throwable {
+        if(mPhoneEmail == null) {
             return;
         }
 
-        attemptRegistration(context);
+        String country = getCountryCode(context);
+
+        attemptRegistration(context, country);
     }
 
-    protected abstract void attemptRegistration(Context context) throws Throwable;
+    protected abstract void attemptRegistration(Context context, String country) throws Throwable;
 
     protected boolean matchesEmail(String email)
     {

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
@@ -15,15 +15,15 @@ import org.dosomething.letsdothis.utils.AppPrefs;
  */
 public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
 {
-    protected final String phoneEmail;
-    protected final String password;
+    private final String mPhoneEmail;
+    protected final String mPassword;
 
-    protected BaseRegistrationTask(String phoneEmail, String password)
+    protected BaseRegistrationTask(String email, String password)
     {
-        this.phoneEmail = phoneEmail.isEmpty()
+        mPhoneEmail = email.isEmpty()
                 ? null
-                : phoneEmail;
-        this.password = password;
+                : email;
+        mPassword = password;
     }
 
     protected void loginUser(Context context, User user) throws Throwable
@@ -45,7 +45,7 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
     @Override
     protected void run(Context context) throws Throwable
     {
-        if(phoneEmail == null)
+        if(mPhoneEmail == null)
         {
             return;
         }
@@ -55,9 +55,9 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
 
     protected abstract void attemptRegistration(Context context) throws Throwable;
 
-    protected boolean matchesEmail(String phoneEmail)
+    protected boolean matchesEmail(String email)
     {
-        return Patterns.EMAIL_ADDRESS.matcher(phoneEmail).matches();
+        return Patterns.EMAIL_ADDRESS.matcher(email).matches();
     }
 
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/LoginTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/LoginTask.java
@@ -19,60 +19,68 @@ public class LoginTask extends BaseRegistrationTask
 {
     private final String mLogin;
 
+    // Flag indicating whether the user doc on the server needs to be updated after login
+    public boolean mUserNeedsUpdate;
+
+    // User object after logging in
+    public User mLoggedInUser;
+
     public LoginTask(String login, String password)
     {
         super(login, password);
 
         mLogin = login;
+        mUserNeedsUpdate = false;
+        mLoggedInUser = null;
     }
 
     /**
      * @TODO this feels like a misnomer because only a login is being attempted here, not a registration
      *
      * @param context
+     * @param country
      * @throws Throwable
      */
     @Override
-    protected void attemptRegistration(Context context) throws Throwable
-    {
+    protected void attemptRegistration(Context context, String country) throws Throwable {
         ResponseLogin response;
-        User user;
+        User user = new User();
+        user.country = country;
 
-        if(matchesEmail(mLogin))
-        {
+        if (matchesEmail(mLogin)) {
             response = NetworkHelper.getNorthstarAPIService().loginWithEmail(mLogin, mPassword);
-            user = new User(mLogin, null, null);
+            user.email = mLogin;
         }
-        else
-        {
+        else {
             response = NetworkHelper.getNorthstarAPIService().loginWithMobile(mLogin, mPassword);
-            user = new User(null, mLogin, null);
+            user.mobile = mLogin;
         }
 
-        validateResponse(context, response, user);
+        mLoggedInUser = validateResponse(context, response, user);
     }
 
-    private void validateResponse(Context context, ResponseLogin response, User user) throws Throwable
-    {
-        if(response != null)
-        {
-            if(response.data._id != null)
-            {
-                //FIXME should we get back a user avatar??
-                user.id = response.data._id;
-                user.drupalId = response.data.drupal_id;
-                user.email = response.data.email;
-                user.mobile = response.data.mobile;
-                user.first_name = response.data.first_name;
-                user.last_name = response.data.last_name;
-                user.birthdate = response.data.birthday;
-                user.avatarPath = response.data.avatar;
-                AppPrefs.getInstance(context).setSessionToken(response.data.session_token);
-                loginUser(context, user);
+    private User validateResponse(Context context, ResponseLogin response, User user) throws Throwable {
+        if (response != null && response.data != null && response.data._id != null) {
+            user.id = response.data._id;
+            user.drupalId = response.data.drupal_id;
+            user.email = response.data.email;
+            user.mobile = response.data.mobile;
+            user.first_name = response.data.first_name;
+            user.last_name = response.data.last_name;
+            user.birthdate = response.data.birthday;
+            user.avatarPath = response.data.photo;
 
-                DatabaseHelper.getInstance(context).getUserDao().createOrUpdate(user);
+            AppPrefs.getInstance(context).setSessionToken(response.data.session_token);
+            loginUser(context, user);
+
+            DatabaseHelper.getInstance(context).getUserDao().createOrUpdate(user);
+
+            if (!user.country.equalsIgnoreCase(response.data.country)) {
+                mUserNeedsUpdate = true;
             }
         }
+
+        return user;
     }
 
     @Override

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/LoginTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/LoginTask.java
@@ -17,27 +17,36 @@ import retrofit.RetrofitError;
  */
 public class LoginTask extends BaseRegistrationTask
 {
+    private final String mLogin;
 
-    public LoginTask(String phoneEmail, String password)
+    public LoginTask(String login, String password)
     {
-        super(phoneEmail, password);
+        super(login, password);
+
+        mLogin = login;
     }
 
+    /**
+     * @TODO this feels like a misnomer because only a login is being attempted here, not a registration
+     *
+     * @param context
+     * @throws Throwable
+     */
     @Override
     protected void attemptRegistration(Context context) throws Throwable
     {
         ResponseLogin response;
         User user;
 
-        if(matchesEmail(phoneEmail))
+        if(matchesEmail(mLogin))
         {
-            response = NetworkHelper.getNorthstarAPIService().loginWithEmail(phoneEmail, password);
-            user = new User(phoneEmail, null, null);
+            response = NetworkHelper.getNorthstarAPIService().loginWithEmail(mLogin, mPassword);
+            user = new User(mLogin, null, null);
         }
         else
         {
-            response = NetworkHelper.getNorthstarAPIService().loginWithMobile(phoneEmail, password);
-            user = new User(null, phoneEmail, null);
+            response = NetworkHelper.getNorthstarAPIService().loginWithMobile(mLogin, mPassword);
+            user = new User(null, mLogin, null);
         }
 
         validateResponse(context, response, user);

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
@@ -13,36 +13,30 @@ import co.touchlab.android.threading.eventbus.EventBusExt;
  */
 public class RegisterTask extends BaseRegistrationTask
 {
-    private final String firstName;
+    private final String SOURCE = "android";
 
-    public RegisterTask(String phoneEmail, String password, String firsttext)
+    private final String mEmail;
+    private final String mPhone;
+    private final String mFirstName;
+
+    public RegisterTask(String email, String phone, String password, String firstName)
     {
-        super(phoneEmail, password);
-        firstName = firsttext;
+        super(email, password);
+
+        mEmail = email;
+        mPhone = phone;
+        mFirstName = firstName;
     }
 
     @Override
     protected void attemptRegistration(Context context) throws Throwable
     {
-        ResponseRegister response;
-        User user = new User(password, firstName);
+        User user = new User(mEmail, mPhone, mPassword);
+        user.first_name = mFirstName;
+        user.source = SOURCE;
 
-        if(matchesEmail(phoneEmail))
-        {
-            user.email = phoneEmail;
-            response = NetworkHelper.getNorthstarAPIService().registerWithEmail(user);
-            user = new User(phoneEmail, null, null);
-        }
-        else
-        {
-            user.mobile = phoneEmail;
-            response = NetworkHelper.getNorthstarAPIService().registerWithMobile(user);
-
-            user = new User(null, phoneEmail, null);
-        }
-
+        ResponseRegister response = NetworkHelper.getNorthstarAPIService().registerWithEmail(user);
         validateResponse(context, response, user);
-
     }
 
     private void validateResponse(Context context, ResponseRegister response, User user) throws Throwable
@@ -54,6 +48,7 @@ public class RegisterTask extends BaseRegistrationTask
                 user.id = response.data._id;
                 user.drupalId = response.data.drupal_id;
                 user.email = response.data.email;
+                user.mobile = response.data.mobile;
                 user.birthdate = response.data.birthday;
                 user.first_name = response.data.first_name;
                 user.last_name = response.data.last_name;

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
@@ -29,10 +29,11 @@ public class RegisterTask extends BaseRegistrationTask
     }
 
     @Override
-    protected void attemptRegistration(Context context) throws Throwable
+    protected void attemptRegistration(Context context, String country) throws Throwable
     {
         User user = new User(mEmail, mPhone, mPassword);
         user.first_name = mFirstName;
+        user.country = country;
         user.source = SOURCE;
 
         ResponseRegister response = NetworkHelper.getNorthstarAPIService().registerWithEmail(user);

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -5,11 +5,11 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.design.widget.Snackbar;
-import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import com.facebook.login.LoginManager;
 import com.squareup.picasso.Picasso;
@@ -19,9 +19,7 @@ import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.FbUser;
 import org.dosomething.letsdothis.tasks.RegisterTask;
 import org.dosomething.letsdothis.tasks.UploadAvatarTask;
-import org.dosomething.letsdothis.ui.adapters.InvitesAdapter;
 import org.dosomething.letsdothis.utils.AppPrefs;
-import org.dosomething.letsdothis.utils.Hashery;
 import org.dosomething.letsdothis.utils.ViewUtils;
 
 import java.io.File;
@@ -41,6 +39,7 @@ public class RegisterActivity extends BaseActivity
 
     //~=~=~=~=~=~=~=~=~=~=~=~=Views
     private EditText  email;
+    private EditText  phone;
     private EditText  password;
     private EditText  firstName;
     private ImageView avatar;
@@ -64,6 +63,11 @@ public class RegisterActivity extends BaseActivity
         initLightning();
 
         FbUser fbUser = (FbUser) getIntent().getSerializableExtra(FB_USER);
+
+        email = (EditText) findViewById(R.id.email);
+        phone = (EditText) findViewById(R.id.phone);
+        password = (EditText) findViewById(R.id.password);
+        firstName = (EditText) findViewById(R.id.first_name);
 
         avatar = (ImageView) findViewById(R.id.avatar);
         avatar.setOnClickListener(new View.OnClickListener()
@@ -106,9 +110,42 @@ public class RegisterActivity extends BaseActivity
 
         String pickTitle = getString(R.string.select_picture);
         Intent chooserIntent = Intent.createChooser(takePhotoIntent, pickTitle);
-        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[] {pickIntent});
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, new Intent[]{pickIntent});
 
         startActivityForResult(chooserIntent, SELECT_PICTURE);
+    }
+
+    /**
+     * Ensures fields are valid to be sent for a registration request.
+     */
+    private boolean validateForRegistration() {
+        boolean isValid = true;
+        firstName.setBackgroundResource(R.drawable.bg_white_rounded_rect_filled);
+        email.setBackgroundResource(R.drawable.bg_white_rounded_rect_filled);
+        password.setBackgroundResource(R.drawable.bg_white_rounded_rect_filled);
+
+        String inputFName = firstName.getText().toString();
+        if (inputFName.isEmpty()) {
+            firstName.setBackgroundResource(R.drawable.edittext_error_background);
+            Toast.makeText(RegisterActivity.this, R.string.error_registration_first_name, Toast.LENGTH_SHORT).show();
+            isValid = false;
+        }
+
+        String inputEmail = email.getText().toString();
+        if (inputEmail.isEmpty() || !inputEmail.matches(".+[@].+[.].+")) {
+            email.setBackgroundResource(R.drawable.edittext_error_background);
+            Toast.makeText(RegisterActivity.this, R.string.error_registration_email, Toast.LENGTH_SHORT).show();
+            isValid = false;
+        }
+
+        String inputPassword = password.getText().toString();
+        if (inputPassword.length() < 6) {
+            password.setBackgroundResource(R.drawable.edittext_error_background);
+            Toast.makeText(RegisterActivity.this, R.string.error_registration_password, Toast.LENGTH_SHORT).show();
+            isValid = false;
+        }
+
+        return isValid;
     }
 
     @Override
@@ -167,21 +204,19 @@ public class RegisterActivity extends BaseActivity
 
     private void initRegisterListener()
     {
-        email = (EditText) findViewById(R.id.email);
-        password = (EditText) findViewById(R.id.password);
-        firstName = (EditText) findViewById(R.id.first_name);
-
         findViewById(R.id.register).setOnClickListener(new View.OnClickListener()
         {
             @Override
             public void onClick(View view)
             {
-                String emailText = email.getText().toString();
-                String passtext = password.getText().toString();
-                String firsttext = firstName.getText().toString();
+                if (validateForRegistration()) {
+                    String emailText = email.getText().toString();
+                    String passtext = password.getText().toString();
+                    String firsttext = firstName.getText().toString();
 
-                TaskQueue.loadQueueDefault(RegisterActivity.this).execute(
-                        new RegisterTask(emailText, passtext, firsttext));
+                    TaskQueue.loadQueueDefault(RegisterActivity.this).execute(
+                            new RegisterTask(emailText, passtext, firsttext));
+                }
             }
         });
     }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -127,22 +127,25 @@ public class RegisterActivity extends BaseActivity
 
         String inputFName = firstName.getText().toString();
         if (inputFName.isEmpty()) {
+            String fnameError = getResources().getString(R.string.error_registration_first_name);
+            firstName.setError(fnameError);
             firstName.setBackgroundResource(R.drawable.edittext_error_background);
-            Toast.makeText(RegisterActivity.this, R.string.error_registration_first_name, Toast.LENGTH_SHORT).show();
             isValid = false;
         }
 
         String inputEmail = email.getText().toString();
         if (inputEmail.isEmpty() || !Patterns.EMAIL_ADDRESS.matcher(inputEmail).matches()) {
+            String emailError = getResources().getString(R.string.error_registration_email);
+            email.setError(emailError);
             email.setBackgroundResource(R.drawable.edittext_error_background);
-            Toast.makeText(RegisterActivity.this, R.string.error_registration_email, Toast.LENGTH_SHORT).show();
             isValid = false;
         }
 
         String inputPassword = password.getText().toString();
         if (inputPassword.length() < 6) {
+            String passwordError = getResources().getString(R.string.error_registration_password);
+            password.setError(passwordError);
             password.setBackgroundResource(R.drawable.edittext_error_background);
-            Toast.makeText(RegisterActivity.this, R.string.error_registration_password, Toast.LENGTH_SHORT).show();
             isValid = false;
         }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.design.widget.Snackbar;
 import android.util.Log;
+import android.util.Patterns;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -132,7 +133,7 @@ public class RegisterActivity extends BaseActivity
         }
 
         String inputEmail = email.getText().toString();
-        if (inputEmail.isEmpty() || !inputEmail.matches(".+[@].+[.].+")) {
+        if (inputEmail.isEmpty() || !Patterns.EMAIL_ADDRESS.matcher(inputEmail).matches()) {
             email.setBackgroundResource(R.drawable.edittext_error_background);
             Toast.makeText(RegisterActivity.this, R.string.error_registration_email, Toast.LENGTH_SHORT).show();
             isValid = false;
@@ -211,11 +212,12 @@ public class RegisterActivity extends BaseActivity
             {
                 if (validateForRegistration()) {
                     String emailText = email.getText().toString();
-                    String passtext = password.getText().toString();
-                    String firsttext = firstName.getText().toString();
+                    String phoneText = phone.getText().toString();
+                    String passText = password.getText().toString();
+                    String firstText = firstName.getText().toString();
 
                     TaskQueue.loadQueueDefault(RegisterActivity.this).execute(
-                            new RegisterTask(emailText, passtext, firsttext));
+                            new RegisterTask(emailText, phoneText, passText, firstText));
                 }
             }
         });

--- a/app/src/main/res/drawable/edittext_error_background.xml
+++ b/app/src/main/res/drawable/edittext_error_background.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" >
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="2dp"
+        android:color="#ff0000"/>
+    <padding
+        android:left="@dimen/padding_small"
+        android:right="@dimen/padding_small"
+        android:top="10dp"
+        android:bottom="10dp"/>
+    <corners
+        android:topLeftRadius="2dp"
+        android:topRightRadius="2dp"
+        android:bottomLeftRadius="2dp"
+        android:bottomRightRadius="2dp"/>
+</shape>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,9 @@
     </string>
     <string name="done">Done</string>
     <string name="error_code_length">An invite code should be 15 characters long!</string>
+    <string name="error_registration_email">We need a valid email</string>
+    <string name="error_registration_first_name">We need your first name</string>
+    <string name="error_registration_password">Your password must be 6+ characters</string>
     <string name="tell_us">Tell us about yourself!</string>
     <string name="footer_register">Have a DoSomething.org account? Sign in</string>
     <string name="footer_forgot_pw">Forgot Password</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,8 @@
     </string>
     <string name="done">Done</string>
     <string name="error_code_length">An invite code should be 15 characters long!</string>
+    <string name="error_login_phone_email">Must not be empty</string>
+    <string name="error_login_password">Must not be empty</string>
     <string name="error_registration_email">We need a valid email</string>
     <string name="error_registration_first_name">We need your first name</string>
     <string name="error_registration_password">Your password must be 6+ characters</string>


### PR DESCRIPTION
#### What's this PR do?
- Adds input validation + error stylings to login and register forms before sending.
- Sends `source=android` as a property when registering a new user
- Sends current configured country code on login and registration

#### More notes
- If on login, the user's `country` has already been set and is the same as the phone's current configuration, then no user update request will be sent.
- The country is also determined based on the user's phone's configuration. It's more immediate, doesn't require any special permission and covers a large majority of our use cases. Where it fails is if users are hopping from one country to another, or users who are in one country but configure their phones to use the locale of a different country.
- **ResponseUserUpdate:** This response has been fixed on the server to return a user object instead of just an `updated_at` object
- No longer setting `source` in **User** because a user could've registered on the web. `source` is only sent on registration now and not on login.

#### Megaspec
1.5.3
1.5.13
1.5.14