### PR TITLE
Campaign detail view update

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
@@ -47,11 +47,13 @@ public interface NorthstarAPI
             : "http://northstar.dosomething.org/v1";
 
     @FormUrlEncoded
+    @Headers("Accept: application/json")
     @POST("/login")
     ResponseLogin loginWithMobile(@Field("mobile") String mobile, @Field(
             "password") String password) throws NetworkException;
 
     @FormUrlEncoded
+    @Headers("Accept: application/json")
     @POST("/login")
     ResponseLogin loginWithEmail(@Field("email") String email, @Field(
             "password") String password) throws NetworkException;

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaign.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaign.java
@@ -33,8 +33,8 @@ public class ResponseCampaign
         campaign.endTime = getMillisFromString(response.getMobileAppTiming().getDates().end);
         campaign.imagePath = response.getCoverImage().getWrapper().getSizes().getLandscape()
                 .getUri();
-        campaign.solutionCopy = response.getSolutions().getCopy().formatted;
-        campaign.solutionSupport = response.getSolutions().getCopy().formatted;
+        campaign.solutionCopy = response.getSolutions().getCopy().raw;
+        campaign.solutionSupport = response.getSolutions().getSupportCopy().raw;
         campaign.problemFact = response.getFacts().getProblem();
         campaign.count = "";//response.getCountString();
         campaign.showShare = Campaign.UploadShare.SHOW_OFF;

--- a/app/src/main/java/org/dosomething/letsdothis/ui/LoginActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/LoginActivity.java
@@ -63,12 +63,6 @@ public class LoginActivity extends BaseActivity
                 startActivity(browserIntent);
             }
         });
-
-        if(BuildConfig.DEBUG)
-        {
-            phoneEmail.setText("touch@lab.co");
-            password.setText("test");
-        }
     }
 
     private void initLoginListener()

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -2,8 +2,6 @@ package org.dosomething.letsdothis.ui.adapters;
 import android.content.Context;
 import android.content.res.Resources;
 import android.support.v7.widget.RecyclerView;
-import android.text.Html;
-import android.text.Spanned;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,7 +12,6 @@ import android.widget.TextView;
 
 import com.squareup.picasso.Picasso;
 
-import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.Campaign;
 import org.dosomething.letsdothis.data.Kudos;
@@ -167,26 +164,19 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                     .resize(0, height).into(campaignViewHolder.imageView);
             campaignViewHolder.title.setText(campaign.title);
             campaignViewHolder.callToAction.setText(campaign.callToAction);
-            campaignViewHolder.problemFact.setText(campaign.problemFact.replaceAll("\\r\\n", ""));
-            if(BuildConfig.DEBUG && campaign.solutionCopy != null) //FIXME this is null sometime
-            {
-                String cleanText = campaign.solutionCopy.replace("\n", "");
-                campaignViewHolder.solutionCopy.setText(Html.fromHtml(cleanText));
+
+            if (campaign.solutionCopy != null) {
+                campaignViewHolder.solutionCopy.setText(campaign.solutionCopy.trim());
             }
-            else
-            {
+            else {
                 campaignViewHolder.solutionCopy.setVisibility(View.GONE);
             }
-            if(BuildConfig.DEBUG && campaign.solutionSupport != null) //FIXME this is null sometime
-            {
-                //FIXME also this is a problem. might need to filter the text as soon as we get in from the response.
-                Spanned spanned = Html.fromHtml(campaign.solutionSupport);
-                String cleanText = spanned.toString().replace("\n", "");
-                campaignViewHolder.solutionSupport.setText(cleanText);
+
+            if (campaign.solutionSupport != null) {
+                campaignViewHolder.solutionSupport.setText(campaign.solutionSupport.trim());
             }
-            else
-            {
-                campaignViewHolder.solutionCopy.setVisibility(View.GONE);
+            else {
+                campaignViewHolder.solutionSupport.setVisibility(View.GONE);
             }
 
             SlantedBackgroundDrawable background = new SlantedBackgroundDrawable(true, webOrange,
@@ -380,7 +370,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     {
         protected TextView  solutionSupport;
         protected TextView  solutionCopy;
-        protected TextView  problemFact;
         protected ImageView imageView;
         protected TextView  title;
         protected TextView  callToAction;
@@ -395,7 +384,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             this.imageView = (ImageView) itemView.findViewById(R.id.image);
             this.title = (TextView) itemView.findViewById(R.id.title);
             this.callToAction = (TextView) itemView.findViewById(R.id.call_to_action);
-            this.problemFact = (TextView) itemView.findViewById(R.id.problemFact);
             this.solutionCopy = (TextView) itemView.findViewById(R.id.solutionCopy);
             this.solutionSupport = (TextView) itemView.findViewById(R.id.solutionSupport);
             this.proveShare = (Button) itemView.findViewById(R.id.prove_share);

--- a/app/src/main/res/layout/item_campaign_details.xml
+++ b/app/src/main/res/layout/item_campaign_details.xml
@@ -33,39 +33,25 @@
         android:textSize="@dimen/text_48"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_above="@+id/call_to_action"
+        android:layout_alignBottom="@+id/image_container"
         android:layout_centerHorizontal="true"
+        android:gravity="center"
+        android:paddingBottom="@dimen/padding_medium"
         android:paddingLeft="@dimen/padding_medium"
         android:paddingRight="@dimen/padding_medium"
-        android:layout_above="@+id/call_to_action"
-        android:gravity="center"
         tool:text="title"/>
 
     <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
         android:id="@+id/call_to_action"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:textAppearanceLarge"
-        android:textColor="@color/white"
-        android:textSize="@dimen/text_33"
-        android:layout_alignBottom="@+id/image_container"
+        android:layout_below="@+id/image_container"
         android:gravity="center"
-        android:paddingLeft="@dimen/padding_medium"
-        android:paddingRight="@dimen/padding_medium"
-        android:layout_marginBottom="@dimen/padding_large"
-        android:layout_centerHorizontal="true"
-        tool:text="call to action. make chocolate and give to all the people because it has antioxidants."/>
-
-    <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
-        android:id="@+id/problemFact"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:paddingLeft="@dimen/padding_small"
-        android:paddingRight="@dimen/padding_small"
-        android:paddingTop="@dimen/padding_small"
+        android:padding="@dimen/padding_medium"
         android:textColor="@android:color/black"
         android:textSize="@dimen/text_33"
-        android:layout_below="@+id/image_container"
-        tool:text="problem fact"/>
+        tool:text="call to action. make chocolate and give to all the people because it has antioxidants."/>
 
     <LinearLayout
         android:id="@+id/solutionWrapper"
@@ -77,7 +63,7 @@
         android:paddingRight="@dimen/padding_small"
         android:paddingBottom="@dimen/padding_small"
         android:background="@color/web_orange"
-        android:layout_below="@+id/problemFact">
+        android:layout_below="@+id/call_to_action">
 
         <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
             android:layout_width="wrap_content"
@@ -93,11 +79,11 @@
             android:layout_below="@+id/image_container"
             android:text="@string/do_something_about_it"/>
 
-
         <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
             android:id="@+id/solutionCopy"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/padding_medium"
             android:textColor="@color/white"
             android:textSize="@dimen/text_33"
             tool:text="solution copy"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     </string>
     <string name="settings">Settings</string>
     <string name="rate">Rate Let\'s Do This</string>
-    <string name="people_doing_it">People Doing It</string>
+    <string name="people_doing_it">Who\'s Doing It Now</string>
     <string name="account">Account</string>
     <string name="change_photo">Change Photo</string>
     <string name="receive_notifications">Receive Notifications</string>
@@ -75,7 +75,7 @@
     <string name="ok">Ok</string>
     <string name="prompt_logout">Are you sure? We’ll miss you.</string>
     <string name="cancel">Cancel</string>
-    <string name="do_something_about_it">Do Something About It</string>
+    <string name="do_something_about_it">Do This</string>
     <string name="share_code">Share Code</string>
     <string name="desc_campaign_invite">When a friend uses your code, they join your action group.
         You can rock %s together and unlock rewards as a group.


### PR DESCRIPTION
#### What's this PR do?
Primarily, this does a little clean up in the campaign detail view. The problem fact section is removed, the call to action tagline is brought down below the image, and the solution copy and support fields pull their data from `raw` instead of `formatted`.

A couple other non-campaign detail related changes:
- The login calls have the `Accept: application/json` header added. When login fails, the logs showed that the response was an html page. If ever we needed to do better handling of login errors based on the API response, it'll be easier working with it as json - also saves us from unnecessary log spam.
- The login form also used to show by default a "touch@lab.co" account. This is removed in anticipation of debug builds going out to more test phones.

#### Megaspec
3.0.0