### PR TITLE
Public Profile Hub

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GetUserCampaignsTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GetUserCampaignsTask.java
@@ -9,7 +9,6 @@ import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.NorthstarAPI;
 import org.dosomething.letsdothis.network.models.ResponseCampaignList;
 import org.dosomething.letsdothis.network.models.ResponseUserCampaign;
-import org.dosomething.letsdothis.utils.AppPrefs;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,21 +21,24 @@ import co.touchlab.android.threading.eventbus.EventBusExt;
 /**
  * Created by toidiu on 4/16/15.
  */
-public class GetCurrentUserCampaignsTask extends BaseNetworkErrorHandlerTask {
+public class GetUserCampaignsTask extends BaseNetworkErrorHandlerTask {
+    // User id we're getting campaigns info for
+    private String mUserId;
+
     // Campaigns a user is participating in
     public List<Campaign> currentCampaignList;
 
     // Campaigns that have ended that a user participated in
     public List<Campaign> pastCampaignList;
 
-    public GetCurrentUserCampaignsTask() {
+    public GetUserCampaignsTask(String id) {
+        mUserId = id;
     }
 
     @Override
     protected void run(Context context) throws Throwable {
         NorthstarAPI northstarAPIService = NetworkHelper.getNorthstarAPIService();
-        ResponseUserCampaign userCampaigns = northstarAPIService
-                .getUserCampaigns(AppPrefs.getInstance(context).getCurrentUserId());
+        ResponseUserCampaign userCampaigns = northstarAPIService.getUserCampaigns(mUserId);
 
         getCurrentCampaign(userCampaigns);
         getPastCampaign(context, userCampaigns);

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GetUserTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GetUserTask.java
@@ -29,6 +29,7 @@ public class GetUserTask extends BaseNetworkErrorHandlerTask
 
         user = ResponseUser.getUser(response);
 
+        // @TODO we should maybe not allow this to run if id != user current id
         DatabaseHelper.getInstance(context).getUserDao().createOrUpdate(user);
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackDetailsActivity.java
@@ -158,14 +158,10 @@ public class ReportBackDetailsActivity extends BaseActivity
         actionQuantity = String.valueOf(reportBack.reportback.quantity);
         setImpactTextIfReady();
 
-        // Tapping on user's name should open up that user's profile
-        name.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent i = PublicProfileActivity.getLaunchIntent(ReportBackDetailsActivity.this, reportBack.user.id);
-                startActivity(i);
-            }
-        });
+        // Tapping on user's name or picture should open up that user's profile
+        OnUserClickListener onUserClickListener = new OnUserClickListener(reportBack.user.id);
+        name.setOnClickListener(onUserClickListener);
+        avatar.setOnClickListener(onUserClickListener);
 
     }
 
@@ -178,5 +174,22 @@ public class ReportBackDetailsActivity extends BaseActivity
         actionNoun = task.campaign.noun;
         actionVerb = task.campaign.verb;
         setImpactTextIfReady();
+    }
+
+    /**
+     * OnClickListener to open up a user's public profile screen.
+     */
+    private class OnUserClickListener implements View.OnClickListener {
+        private String mUserId;
+
+        public OnUserClickListener(String id) {
+            mUserId = id;
+        }
+
+        @Override
+        public void onClick(View v) {
+            Intent i = PublicProfileActivity.getLaunchIntent(ReportBackDetailsActivity.this, mUserId);
+            startActivity(i);
+        }
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackDetailsActivity.java
@@ -32,6 +32,7 @@ public class ReportBackDetailsActivity extends BaseActivity
 
     //~=~=~=~=~=~=~=~=~=~=~=~=Views
     private ImageView image;
+    private ImageView avatar;
     private TextView  location;
     private TextView  title;
     private TextView  caption;
@@ -51,6 +52,7 @@ public class ReportBackDetailsActivity extends BaseActivity
         setContentView(R.layout.activity_report_back_details);
 
         image = (ImageView) findViewById(R.id.image);
+        avatar = (ImageView) findViewById(R.id.avatar);
         location = (TextView) findViewById(R.id.location);
         title = (TextView) findViewById(R.id.title);
         caption = (TextView) findViewById(R.id.caption);
@@ -104,47 +106,67 @@ public class ReportBackDetailsActivity extends BaseActivity
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(ReportBackDetailsTask task)
-    {
-        if(task.reportBack != null)
-        {
-            final ReportBack reportBack = task.reportBack;
-
-            Picasso.with(this).load(reportBack.getImagePath()).resize(image.getWidth(), 0)
-                   .into(image);
-
-            if (reportBack.user.country != null && !reportBack.user.country.isEmpty()) {
-                Locale locale = new Locale("", reportBack.user.country);
-                location.setText(locale.getDisplayCountry());
-            }
-
-            title.setText(reportBack.campaign.title);
-            title.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    startActivity(CampaignDetailsActivity
-                            .getLaunchIntent(ReportBackDetailsActivity.this,
-                                    reportBack.campaign.id));
-                }
-            });
-
-            caption.setText(reportBack.caption);
-
-            String username = reportBack.user.first_name;
-            if (reportBack.user.last_name != null && !reportBack.user.last_name.isEmpty()) {
-                username += " " + reportBack.user.last_name.charAt(0) + ".";
-            }
-            name.setText(username);
-
-            toolbar.setTitle(reportBack.campaign.title);
-
-            actionQuantity = String.valueOf(reportBack.reportback.quantity);
-            setImpactTextIfReady();
-        }
-        else
-        {
+    public void onEventMainThread(ReportBackDetailsTask task) {
+        if (task.reportBack == null) {
             Toast.makeText(this, "report back data failed", Toast.LENGTH_SHORT).show();
+            return;
         }
+
+        final ReportBack reportBack = task.reportBack;
+
+        // Report back photo
+        Picasso.with(this).load(reportBack.getImagePath()).resize(image.getWidth(), 0)
+               .into(image);
+
+        // Campaign title
+        title.setText(reportBack.campaign.title);
+        title.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(CampaignDetailsActivity
+                        .getLaunchIntent(ReportBackDetailsActivity.this,
+                                reportBack.campaign.id));
+            }
+        });
+
+        // Report back caption
+        caption.setText(reportBack.caption);
+
+        // User name
+        String username = reportBack.user.first_name;
+        if (reportBack.user.last_name != null && !reportBack.user.last_name.isEmpty()) {
+            username += " " + reportBack.user.last_name.charAt(0) + ".";
+        }
+        name.setText(username);
+
+        // User country location
+        if (reportBack.user.country != null && !reportBack.user.country.isEmpty()) {
+            Locale locale = new Locale("", reportBack.user.country);
+            location.setText(locale.getDisplayCountry());
+        }
+
+        // User profile photo
+        if (reportBack.user.avatarPath != null && !reportBack.user.avatarPath.isEmpty()) {
+            Picasso.with(this).load(reportBack.user.avatarPath)
+                    .placeholder(R.drawable.default_profile_photo)
+                    .resizeDimen(R.dimen.friend_avatar, R.dimen.friend_avatar)
+                    .into(avatar);
+        }
+
+        toolbar.setTitle(reportBack.campaign.title);
+
+        actionQuantity = String.valueOf(reportBack.reportback.quantity);
+        setImpactTextIfReady();
+
+        // Tapping on user's name should open up that user's profile
+        name.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent i = PublicProfileActivity.getLaunchIntent(ReportBackDetailsActivity.this, reportBack.user.id);
+                startActivity(i);
+            }
+        });
+
     }
 
     @SuppressWarnings("UnusedDeclarations")

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -224,43 +224,51 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         {
             final ReportBack reportBack = (ReportBack) dataSet.get(position);
             final ReportBackViewHolder reportBackViewHolder = (ReportBackViewHolder) holder;
-
-            //FIXME get real avatar
-            reportBackViewHolder.avatar.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    detailsAdapterClickListener.onUserClicked(reportBack.user.id);
-                }
-            });
-
             final Context context = reportBackViewHolder.itemView.getContext();
+
+            // Report back photo
             Picasso.with(context).
                     load(reportBack.getImagePath()).into(reportBackViewHolder.imageView);
 
+            // User name
             String reportbackName = reportBack.user.first_name;
             if (reportBack.user.last_name != null && !reportBack.user.last_name.isEmpty()) {
                 reportbackName += " " + reportBack.user.last_name.charAt(0) + ".";
             }
             reportBackViewHolder.name.setText(reportbackName);
 
+            // User country location
             if (reportBack.user.country != null && !reportBack.user.country.isEmpty()) {
                 Locale locale = new Locale("", reportBack.user.country);
                 reportBackViewHolder.location.setText(locale.getDisplayCountry());
             }
 
+            // User profile photo
+            if (reportBack.user.avatarPath != null && !reportBack.user.avatarPath.isEmpty()) {
+                Picasso.with(context).load(reportBack.user.avatarPath)
+                        .placeholder(R.drawable.default_profile_photo)
+                        .resizeDimen(R.dimen.friend_avatar, R.dimen.friend_avatar)
+                        .into(reportBackViewHolder.avatar);
+            }
+
+            // Report back campaign name and details
             reportBackViewHolder.title.setText(currentCampaign.title);
             reportBackViewHolder.caption.setText(reportBack.caption);
 
             String impactText = String.format("%s %s %s", String.valueOf(reportBack.reportback.quantity),
                     currentCampaign.noun, currentCampaign.verb);
             reportBackViewHolder.impact.setText(impactText);
+
+            // Click listeners on the user name and user photo
+            OnUserClickListener onUserClickListener = new OnUserClickListener(reportBack.user.id);
+            reportBackViewHolder.avatar.setOnClickListener(onUserClickListener);
+            reportBackViewHolder.name.setOnClickListener(onUserClickListener);
         }
         else if(getItemViewType(position) == VIEW_TYPE_CAMPAIGN_FOOTER)
         {
             SectionTitleViewHolder sectionTitleViewHolder = (SectionTitleViewHolder) holder;
             sectionTitleViewHolder.textView.setText(sectionTitleViewHolder.textView.getContext()
-                                                                                   .getString(
-                                                                                           R.string.people_doing_it));
+                                                                                   .getString(R.string.people_doing_it));
         }
 
     }
@@ -336,6 +344,22 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             this.caption = (TextView) view.findViewById(R.id.caption);
             this.impact = (TextView) view.findViewById(R.id.impact);
             this.title = (TextView) view.findViewById(R.id.title);
+        }
+    }
+
+    /**
+     * OnClickListener to open up a user's public profile screen.
+     */
+    private class OnUserClickListener implements View.OnClickListener {
+        private String mUserId;
+
+        public OnUserClickListener(String id) {
+            mUserId = id;
+        }
+
+        @Override
+        public void onClick(View v) {
+            detailsAdapterClickListener.onUserClicked(mUserId);
         }
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
@@ -21,7 +21,7 @@ import org.dosomething.letsdothis.data.ReportBack;
 import org.dosomething.letsdothis.tasks.BaseReportBackListTask;
 import org.dosomething.letsdothis.tasks.CampaignSignUpTask;
 import org.dosomething.letsdothis.tasks.DbInterestGroupCampaignListTask;
-import org.dosomething.letsdothis.tasks.GetCurrentUserCampaignsTask;
+import org.dosomething.letsdothis.tasks.GetUserCampaignsTask;
 import org.dosomething.letsdothis.tasks.InterestReportBackListTask;
 import org.dosomething.letsdothis.tasks.UpdateInterestGroupCampaignTask;
 import org.dosomething.letsdothis.tasks.UpdateInterestGroupCampaignTask.IdQuery;
@@ -29,6 +29,7 @@ import org.dosomething.letsdothis.ui.CampaignDetailsActivity;
 import org.dosomething.letsdothis.ui.ReportBackDetailsActivity;
 import org.dosomething.letsdothis.ui.adapters.CampaignAdapter;
 import org.dosomething.letsdothis.ui.views.ActionGridSpacingDecoration;
+import org.dosomething.letsdothis.utils.AppPrefs;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -279,7 +280,8 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
                         FIRST_PAGE, BaseReportBackListTask.STATUS_PROMOTED));
 
                 // Now that we have campaigns, get user info to find out what they've participated in
-                TaskQueue.loadQueueDefault(getActivity()).execute(new GetCurrentUserCampaignsTask());
+                String userId = AppPrefs.getInstance(getActivity()).getCurrentUserId();
+                TaskQueue.loadQueueDefault(getActivity()).execute(new GetUserCampaignsTask(userId));
             }
         }
     }
@@ -300,7 +302,7 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
      * @param task Result of getting current user's campaign activity
      */
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(GetCurrentUserCampaignsTask task) {
+    public void onEventMainThread(GetUserCampaignsTask task) {
         List<Campaign> allCampaigns = new ArrayList<>();
         if (task.currentCampaignList != null) {
             allCampaigns.addAll(task.currentCampaignList);

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -21,7 +21,7 @@ import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.Campaign;
 import org.dosomething.letsdothis.data.DatabaseHelper;
 import org.dosomething.letsdothis.tasks.DbGetUserTask;
-import org.dosomething.letsdothis.tasks.GetCurrentUserCampaignsTask;
+import org.dosomething.letsdothis.tasks.GetUserCampaignsTask;
 import org.dosomething.letsdothis.tasks.GetUserTask;
 import org.dosomething.letsdothis.tasks.RbShareDataTask;
 import org.dosomething.letsdothis.tasks.ReportbackUploadTask;
@@ -86,7 +86,11 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
     {
         super.onAttach(activity);
         titleListener = (SetTitleListener) getActivity();
-        replaceFragmentListener = (ReplaceFragmentListener) activity;
+
+        if (activity instanceof ReplaceFragmentListener) {
+            replaceFragmentListener = (ReplaceFragmentListener) activity;
+        }
+
         refreshUserCampaign();
     }
 
@@ -263,16 +267,20 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
     }
 
 
-    private void refreshUserCampaign()
-    {
-        TaskQueue.loadQueueDefault(getActivity()).execute(new GetCurrentUserCampaignsTask());
+    private void refreshUserCampaign() {
+        String userId = getArguments().getString(EXTRA_ID, null);
+        if (userId == null) {
+            userId = AppPrefs.getInstance(getActivity()).getCurrentUserId();
+        }
+
+        TaskQueue.loadQueueDefault(getActivity()).execute(new GetUserCampaignsTask(userId));
         refreshProgressBar();
     }
 
     private void refreshProgressBar()
     {
         boolean b = TaskQueueHelper.hasTasksOfType(TaskQueue.loadQueueDefault(getActivity()),
-                                                   GetCurrentUserCampaignsTask.class);
+                                                   GetUserCampaignsTask.class);
         if(b)
         {
             if(progress != null)
@@ -290,7 +298,7 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(GetCurrentUserCampaignsTask task) {
+    public void onEventMainThread(GetUserCampaignsTask task) {
         refreshProgressBar();
         adapter.setCurrentCampaign(task.currentCampaignList);
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/NotificationsFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/NotificationsFragment.java
@@ -13,15 +13,11 @@ import android.widget.ProgressBar;
 
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.Notification;
-import org.dosomething.letsdothis.tasks.GetCurrentUserCampaignsTask;
 import org.dosomething.letsdothis.ui.adapters.NotificationAdapter;
 import org.dosomething.letsdothis.ui.views.DividerItemDecoration;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import co.touchlab.android.threading.tasks.TaskQueue;
-import co.touchlab.android.threading.tasks.utils.TaskQueueHelper;
 
 /**
  * Created by izzyoji :) on 4/15/15.

--- a/app/src/main/res/layout/item_hub_public_empty.xml
+++ b/app/src/main/res/layout/item_hub_public_empty.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:gravity="center_horizontal"
+    android:orientation="vertical"
+    android:padding="@dimen/padding_medium">
+
+    <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/padding_medium"
+        android:gravity="center_horizontal"
+        android:text="@string/hub_empty_public"
+        android:textColor="@color/gray"
+        android:textSize="@dimen/text_large"
+        android:textStyle="bold"
+        app:typeface="brandon_bold"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="actions">Actions</string>
     <string name="hub">Me</string>
     <string name="hub_empty_action_button">Take Me There</string>
+    <string name="hub_empty_public">Hm, we aren\'t able to find any activity for this user.</string>
     <string name="hub_empty_text1">You aren\'t doing anything right now!</string>
     <string name="hub_empty_text2">We have 12 fresh ideas every month, check them out in the Actions tab.</string>
     <string name="hub_expire_current">Current:</string>


### PR DESCRIPTION
#### What's this PR do?

Other user profiles are now viewable by clicking on either their name or profile photo from the gallery in the campaign details screen or in an individual reportback detail screen.

- Public Hub view is modified to hide action buttons and image container when no reportback photo is available
- Added a separate empty view for public profiles
- GetCurrentUserCampaignsTask was modified to a more generic GetUserCampaignsTask. A user id now needs to be provided to the task
- A user's photo (if any) in the campaign details gallery should now display correctly

#### Megaspec
2.2.4
3.0.3
5.2.0