### PR TITLE
Campaign Detail pre-signup state

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
@@ -7,6 +7,7 @@ import org.dosomething.letsdothis.network.models.RequestCampaignSignup;
 import org.dosomething.letsdothis.network.models.ResponseCampaignSignUp;
 import org.dosomething.letsdothis.utils.AppPrefs;
 
+import co.touchlab.android.threading.eventbus.EventBusExt;
 import co.touchlab.android.threading.tasks.Task;
 
 /**
@@ -25,6 +26,7 @@ public class CampaignSignUpTask extends Task
     @Override
     protected void onComplete(Context context)
     {
+        EventBusExt.getDefault().post(this);
         super.onComplete(context);
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -202,8 +202,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
      */
     @Override
     public void onSignupClicked(int campaignId) {
-        Toast.makeText(this, "TODO: execute signup", Toast.LENGTH_SHORT).show();
-        // TaskQueue.loadQueueDefault(this).execute(new CampaignSignUpTask(campaignId));
+         TaskQueue.loadQueueDefault(this).execute(new CampaignSignUpTask(campaignId));
     }
 
     @Override
@@ -349,6 +348,6 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(CampaignSignUpTask task) {
-        // @TODO update the view in the adapter after a successful signup
+        adapter.refreshOnSignup();
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -36,7 +36,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     private final int slantHeight;
     private final int widthOvershoot;
     private final int heightShadowOvershoot;
-    private final boolean mUserIsSignedUp;
 
     //~=~=~=~=~=~=~=~=~=~=~=~=Fields
     private ArrayList<Object> dataSet = new ArrayList<>();
@@ -44,6 +43,11 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
 
     private Campaign currentCampaign;
 
+    // Flag indicating if the current user is signed up for this campaign
+    private boolean mUserIsSignedUp;
+
+    // Flag indicating a signup is in progress
+    private boolean mSignupInProgress;
 
     public CampaignDetailsAdapter(DetailsAdapterClickListener detailsAdapterClickListener,
                                   Resources resources, boolean isSignedUp) {
@@ -55,6 +59,7 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         widthOvershoot = resources.getDimensionPixelSize(R.dimen.space_50);
         heightShadowOvershoot = resources.getDimensionPixelSize(R.dimen.padding_tiny);
         mUserIsSignedUp = isSignedUp;
+        mSignupInProgress = false;
     }
 
     public void updateCampaign(Campaign campaign)
@@ -101,6 +106,16 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             dataSet.set(0, currentCampaign);
             notifyItemChanged(0);
         }
+    }
+
+    /**
+     * Update the view of the adapter when the
+     */
+    public void refreshOnSignup() {
+        mUserIsSignedUp = true;
+        mSignupInProgress = false;
+
+        notifyDataSetChanged();
     }
 
     public interface DetailsAdapterClickListener
@@ -159,6 +174,14 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             campaignViewHolder.title.setText(campaign.title);
             campaignViewHolder.callToAction.setText(campaign.callToAction);
 
+            // Signup progress bar
+            if (mSignupInProgress) {
+                campaignViewHolder.signupProgress.setVisibility(View.VISIBLE);
+            }
+            else {
+                campaignViewHolder.signupProgress.setVisibility(View.GONE);
+            }
+
             // Solution section
             if (!mUserIsSignedUp) {
                 campaignViewHolder.solutionWrapper.setVisibility(View.GONE);
@@ -206,6 +229,9 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                 @Override
                 public void onClick(View v) {
                     if (!mUserIsSignedUp) {
+                        mSignupInProgress = true;
+                        notifyDataSetChanged();
+
                         detailsAdapterClickListener.onSignupClicked(campaign.id);
                     }
                     else if(campaign.showShare == Campaign.UploadShare.SHARE) {
@@ -304,6 +330,7 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         protected TextView  title;
         protected TextView  callToAction;
         protected Button    actionButton;
+        protected View      signupProgress;
         public    View      solutionWrapper;
 
         public CampaignViewHolder(View itemView)
@@ -316,6 +343,7 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             this.solutionCopy = (TextView) itemView.findViewById(R.id.solutionCopy);
             this.solutionSupport = (TextView) itemView.findViewById(R.id.solutionSupport);
             this.actionButton = (Button) itemView.findViewById(R.id.action_button);
+            this.signupProgress = itemView.findViewById(R.id.progress);
         }
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -210,15 +210,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                     }
                 }
             });
-
-            campaignViewHolder.invite.setOnClickListener(new View.OnClickListener()
-            {
-                @Override
-                public void onClick(View v)
-                {
-                    detailsAdapterClickListener.inviteClicked();
-                }
-            });
         }
         else if(getItemViewType(position) == VIEW_TYPE_REPORT_BACK)
         {
@@ -307,7 +298,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         protected TextView  title;
         protected TextView  callToAction;
         protected Button    proveShare;
-        protected Button    invite;
         public    View      solutionWrapper;
 
         public CampaignViewHolder(View itemView)
@@ -320,7 +310,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             this.solutionCopy = (TextView) itemView.findViewById(R.id.solutionCopy);
             this.solutionSupport = (TextView) itemView.findViewById(R.id.solutionSupport);
             this.proveShare = (Button) itemView.findViewById(R.id.prove_share);
-            this.invite = (Button) itemView.findViewById(R.id.invite);
         }
     }
 

--- a/app/src/main/res/layout/item_campaign_details.xml
+++ b/app/src/main/res/layout/item_campaign_details.xml
@@ -97,39 +97,20 @@
             tool:text="solution support"/>
     </LinearLayout>
 
-    <LinearLayout
+    <org.dosomething.letsdothis.ui.views.typeface.CustomButton
+        android:id="@+id/prove_share"
+        style="@style/PrimaryButton"
+        app:typeface="brandon_bold"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginTop="@dimen/padding_medium"
+        android:layout_below="@id/solutionWrapper"
         android:layout_marginBottom="@dimen/padding_medium"
-        android:layout_below="@id/solutionWrapper">
-
-        <org.dosomething.letsdothis.ui.views.typeface.CustomButton
-            android:id="@+id/prove_share"
-            style="@style/SecondaryButton"
-            app:typeface="brandon_bold"
-            android:textAllCaps="true"
-            android:textSize="@dimen/text_36"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginLeft="@dimen/padding_tiny"
-            android:layout_marginRight="@dimen/padding_tiny"
-            android:text="@string/show_off"/>
-
-        <org.dosomething.letsdothis.ui.views.typeface.CustomButton
-            style="@style/PrimaryButton"
-            android:id="@+id/invite"
-            app:typeface="brandon_bold"
-            android:textAllCaps="true"
-            android:textSize="@dimen/text_36"
-            android:layout_weight="1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/padding_tiny"
-            android:layout_marginRight="@dimen/padding_tiny"
-            android:text="@string/invite_friends"/>
-    </LinearLayout>
+        android:layout_marginLeft="@dimen/padding_tiny"
+        android:layout_marginRight="@dimen/padding_tiny"
+        android:layout_marginTop="@dimen/padding_medium"
+        android:layout_weight="1"
+        android:textAllCaps="true"
+        android:textSize="@dimen/text_36"
+        android:text="@string/show_off"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_campaign_details.xml
+++ b/app/src/main/res/layout/item_campaign_details.xml
@@ -44,7 +44,7 @@
 
     <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
         android:id="@+id/call_to_action"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/image_container"
         android:gravity="center"
@@ -98,7 +98,7 @@
     </LinearLayout>
 
     <org.dosomething.letsdothis.ui.views.typeface.CustomButton
-        android:id="@+id/prove_share"
+        android:id="@+id/action_button"
         style="@style/PrimaryButton"
         app:typeface="brandon_bold"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_campaign_details.xml
+++ b/app/src/main/res/layout/item_campaign_details.xml
@@ -22,6 +22,16 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@drawable/gradient_270"/>
+
+        <ProgressBar
+            android:id="@+id/progress"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:layout_gravity="bottom|center"
+            android:background="@drawable/bg_progress"
+            android:indeterminate="true"
+            android:visibility="visible"/>
     </FrameLayout>
 
     <org.dosomething.letsdothis.ui.views.typeface.CustomTextView


### PR DESCRIPTION
#### What's this PR do?
The campaign detail screen (for a campaign the user hasn't signed up for) can be reached from the reportbacks of other users. Changes here add design and support for that screen in its pre-signup state.

https://github.com/DoSomething/product/blob/master/LetsDoThis/Screens/Discovery/Campaign%20Presignup.png

- Hiding solution views
- Functional sign up button
- Progress bar while sign up is in progress

Other things that come with those changes:

- The actions for the current user's campaign actions are now saved locally whenever GetUserCampaignsTask is run for that user
- CampaignSignUpTask now posts an event to the default EventBus when it completes

#### Megaspec
3.0.0c