### PR TITLE
Campaigns queried by date. Group titles retrieved from server.

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/data/InterestGroup.java
+++ b/app/src/main/java/org/dosomething/letsdothis/data/InterestGroup.java
@@ -5,8 +5,7 @@ import org.dosomething.letsdothis.R;
 /**
  * Created by izzyoji :) on 6/23/15.
  */
-public enum InterestGroup
-{
+public enum InterestGroup {
     A(R.string.interest_0, BuildConfig.DEBUG
             ? 667
             : 1300),
@@ -23,11 +22,13 @@ public enum InterestGroup
             ? 670
             : 1303);
 
+    // Initial display name resource id
     public int nameResId;
+
+    // Group term id
     public int id;
 
-    private InterestGroup(int nameResId, int id)
-    {
+    InterestGroup(int nameResId, int id) {
         this.nameResId = nameResId;
         this.id = id;
     }

--- a/app/src/main/java/org/dosomething/letsdothis/network/DoSomethingAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/DoSomethingAPI.java
@@ -4,6 +4,7 @@ import org.dosomething.letsdothis.network.models.ResponseCampaignList;
 import org.dosomething.letsdothis.network.models.ResponseCampaignWrapper;
 import org.dosomething.letsdothis.network.models.ResponseReportBack;
 import org.dosomething.letsdothis.network.models.ResponseReportBackList;
+import org.dosomething.letsdothis.network.models.ResponseTaxonomyTerm;
 
 import co.touchlab.android.threading.errorcontrol.NetworkException;
 import retrofit.http.GET;
@@ -47,4 +48,7 @@ public interface DoSomethingAPI
     @Headers("Content-Type: application/json")
     @GET("/campaigns.json?mobile_app=1")
     ResponseCampaignList campaignListByIds(@Query("ids") String ids) throws NetworkException;
+
+    @GET("/taxonomy_term/{id}.json")
+    ResponseTaxonomyTerm taxonomyTerm(@Path("id") int id) throws NetworkException;
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/DoSomethingAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/DoSomethingAPI.java
@@ -39,8 +39,10 @@ public interface DoSomethingAPI
     ResponseReportBack reportBack(@Path("id") int id) throws NetworkException;
 
     @Headers("Content-Type: application/json")
-    @GET("/campaigns.json?mobile_app=1")
-    ResponseCampaignList campaignList(@Query("term_ids")int interestGroupId) throws NetworkException;
+    @GET("/campaigns.json")
+    ResponseCampaignList campaignList(
+            @Query("term_ids") int interestGroupId,
+            @Query("mobile_app_date") String currentDate) throws NetworkException;
 
     @Headers("Content-Type: application/json")
     @GET("/campaigns.json?mobile_app=1")

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseTaxonomyTerm.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseTaxonomyTerm.java
@@ -1,0 +1,12 @@
+package org.dosomething.letsdothis.network.models;
+
+/**
+ * Created by juy on 10/1/15.
+ */
+public class ResponseTaxonomyTerm {
+    // Term id
+    public String tid;
+
+    // Term name
+    public String name;
+}

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GetInterestGroupTitleTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GetInterestGroupTitleTask.java
@@ -1,0 +1,57 @@
+package org.dosomething.letsdothis.tasks;
+
+import android.content.Context;
+
+import org.dosomething.letsdothis.network.DoSomethingAPI;
+import org.dosomething.letsdothis.network.NetworkHelper;
+import org.dosomething.letsdothis.network.models.ResponseTaxonomyTerm;
+
+import java.util.HashMap;
+
+import co.touchlab.android.threading.eventbus.EventBusExt;
+
+/**
+ * Created by juy on 10/1/15.
+ */
+public class GetInterestGroupTitleTask extends BaseNetworkErrorHandlerTask {
+
+    // Interest group term ids
+    final private int[] mGroupIds;
+
+    // Resulting id/name mappings
+    public HashMap<Integer, String> mTermResults;
+
+    public GetInterestGroupTitleTask(int id0, int id1, int id2, int id3) {
+        mGroupIds = new int[4];
+        mTermResults = new HashMap<>();
+
+        mGroupIds[0] = id0;
+        mGroupIds[1] = id1;
+        mGroupIds[2] = id2;
+        mGroupIds[3] = id3;
+    }
+
+    @Override
+    protected void run(Context context) throws Throwable {
+        DoSomethingAPI api = NetworkHelper.getDoSomethingAPIService();
+
+        for (int i = 0; i < 4; i++) {
+            ResponseTaxonomyTerm response = api.taxonomyTerm(mGroupIds[i]);
+            mTermResults.put(Integer.parseInt(response.tid), response.name);
+        }
+    }
+
+    @Override
+    protected void onComplete(Context context) {
+        super.onComplete(context);
+
+        EventBusExt.getDefault().post(this);
+    }
+
+    @Override
+    protected boolean handleError(Context context, Throwable throwable) {
+        super.handleError(context, throwable);
+
+        return false;
+    }
+}

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
@@ -8,8 +8,9 @@ import org.dosomething.letsdothis.data.Campaign;
 import org.dosomething.letsdothis.data.DatabaseHelper;
 import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.models.ResponseCampaignList;
-import org.dosomething.letsdothis.utils.TimeUtils;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import co.touchlab.android.threading.eventbus.EventBusExt;
@@ -21,7 +22,10 @@ import co.touchlab.android.threading.tasks.Task;
  */
 public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
 {
-    public int            interestGroupId;
+    // Interest group id
+    public int interestGroupId;
+
+    // Resulting campaigns
     public List<Campaign> campaigns;
 
     public UpdateInterestGroupCampaignTask(int interestGroupId)
@@ -30,10 +34,11 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
     }
 
     @Override
-    protected void run(Context context) throws Throwable
-    {
+    protected void run(Context context) throws Throwable {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+        String currentDate = df.format(new Date());
         ResponseCampaignList response = NetworkHelper.getDoSomethingAPIService()
-                .campaignList(interestGroupId);
+                .campaignList(interestGroupId, currentDate);
         campaigns = ResponseCampaignList.getCampaigns(response);
 
         Dao<Campaign, String> campDao = DatabaseHelper.getInstance(context).getCampDao();
@@ -42,8 +47,7 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
         db.where().eq(Campaign.INTEREST_GROUP, interestGroupId);
         campDao.delete(db.prepare());
 
-        for(Campaign c : campaigns)
-        {
+        for(Campaign c : campaigns) {
             c.interestGroup = interestGroupId;
             campDao.createOrUpdate(c);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,9 +97,9 @@
     <string name="change_password1_hint">Enter the new password</string>
     <string name="change_password2_hint">Re-enter the new password</string>
     <string name="interest_0">Hot</string>
-    <string name="interest_1">Music</string>
-    <string name="interest_2">Crafts</string>
-    <string name="interest_3">Sports</string>
+    <string name="interest_1">...</string>
+    <string name="interest_2">...</string>
+    <string name="interest_3">...</string>
     <string name="forgot_pw">Forgot Password?</string>
     <string name="notification_kudos">notification_kudos</string>
     <string name="notification_friend">notification_friend</string>


### PR DESCRIPTION
#### What's this PR do?
- Retrieves campaigns by the current date instead of just whatever had `mobile_app=1`set. This will make for easier management of the content on the app side from month to month. Also, ideally puts the app in a place where we don't really have to worry about displaying campaigns that are closed.
- The group names displayed in the main feed are now also retrieved from the server. The new `GetInterestGroupTitleTask` handles the retrieval.

#### Potential problems
The `taxonomy_term` endpoint used to get the tag names needs to be enabled. Even after manually enabling it, it seems like it gets automatically disabled every time there's a deploy to the server.

https://github.com/DoSomething/phoenix/issues/5342 was added to resolve this

#### Megaspec
2.0.12