### PR TITLE
Crash fixes + error handling on main feed

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
@@ -17,24 +17,38 @@ import co.touchlab.android.threading.tasks.Task;
  */
 //todo should this be persisted
 public class CampaignSignUpTask extends Task {
-    private int campaignId;
+    // Campaign ID the signup is for
+    private int mCampaignId;
 
-    private boolean hasError;
+    // Pager position the signup came from
+    private int mPagerPosition;
+
+    // Set to true if an error occurs
+    private boolean mHasError;
 
     public CampaignSignUpTask(int campaignId) {
-        this.campaignId = campaignId;
-        this.hasError = false;
+        this.mCampaignId = campaignId;
+    }
+
+    public CampaignSignUpTask(int campaignId, int pagerPosition) {
+        this.mCampaignId = campaignId;
+        this.mPagerPosition = pagerPosition;
+        this.mHasError = false;
     }
 
     //
     // Getters
     //
     public int getCampaignId() {
-        return campaignId;
+        return mCampaignId;
+    }
+
+    public int getPagerPosition() {
+        return mPagerPosition;
     }
 
     public boolean hasError() {
-        return hasError;
+        return mHasError;
     }
 
     @Override
@@ -45,15 +59,15 @@ public class CampaignSignUpTask extends Task {
 
     @Override
     protected void run(Context context) throws Throwable {
-        CampaignActions actions = CampaignActions.queryForId(context, campaignId);
+        CampaignActions actions = CampaignActions.queryForId(context, mCampaignId);
         if (actions == null || actions.signUpId <= 0) {
             String sessionToken = AppPrefs.getInstance(context).getSessionToken();
             RequestCampaignSignup requestCampaignSignup = new RequestCampaignSignup(null);
             ResponseCampaignSignUp response = NetworkHelper.getNorthstarAPIService()
                                                            .campaignSignUp(requestCampaignSignup,
-                                                                           campaignId, sessionToken);
+                                                                           mCampaignId, sessionToken);
             CampaignActions campaignActions = new CampaignActions();
-            campaignActions.campaignId = campaignId;
+            campaignActions.campaignId = mCampaignId;
             campaignActions.signUpId = ResponseCampaignSignUp.getSignUpId(response);
             CampaignActions.save(context, campaignActions);
         }
@@ -62,7 +76,7 @@ public class CampaignSignUpTask extends Task {
     @Override
     protected boolean handleError(Context context, Throwable throwable) {
         Toast.makeText(context, context.getString(R.string.error_signup), Toast.LENGTH_SHORT).show();
-        hasError = true;
+        mHasError = true;
         return true;
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GetInterestGroupTitleTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GetInterestGroupTitleTask.java
@@ -1,7 +1,9 @@
 package org.dosomething.letsdothis.tasks;
 
 import android.content.Context;
+import android.widget.Toast;
 
+import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.network.DoSomethingAPI;
 import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.models.ResponseTaxonomyTerm;
@@ -52,6 +54,7 @@ public class GetInterestGroupTitleTask extends BaseNetworkErrorHandlerTask {
     protected boolean handleError(Context context, Throwable throwable) {
         super.handleError(context, throwable);
 
-        return false;
+        Toast.makeText(context, context.getString(R.string.error_interest_group_titles), Toast.LENGTH_SHORT).show();
+        return true;
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
@@ -1,9 +1,11 @@
 package org.dosomething.letsdothis.tasks;
 import android.content.Context;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.j256.ormlite.dao.Dao;
 
+import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.DatabaseHelper;
 import org.dosomething.letsdothis.data.User;
 import org.dosomething.letsdothis.network.NetworkHelper;
@@ -51,7 +53,8 @@ public class UploadAvatarTask extends Task
     @Override
     protected boolean handleError(Context context, Throwable e)
     {
-        return false;
+        Toast.makeText(context, context.getString(R.string.error_avatar_upload), Toast.LENGTH_SHORT).show();
+        return true;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="error_registration_email">We need a valid email</string>
     <string name="error_registration_first_name">We need your first name</string>
     <string name="error_registration_password">Your password must be 6+ characters</string>
+    <string name="error_signup">There was an error signing up for the campaign</string>
     <string name="tell_us">Tell us about yourself!</string>
     <string name="footer_register">Have a DoSomething.org account? Sign in</string>
     <string name="footer_forgot_pw">Forgot Password</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="done">Done</string>
     <string name="error_avatar_upload">There was an error uploading your photo</string>
     <string name="error_code_length">An invite code should be 15 characters long!</string>
+    <string name="error_interest_group_titles">There was an error getting campaign info</string>
     <string name="error_login_phone_email">Must not be empty</string>
     <string name="error_login_password">Must not be empty</string>
     <string name="error_registration_email">We need a valid email</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
         %2$s.
     </string>
     <string name="done">Done</string>
+    <string name="error_avatar_upload">There was an error uploading your photo</string>
     <string name="error_code_length">An invite code should be 15 characters long!</string>
     <string name="error_login_phone_email">Must not be empty</string>
     <string name="error_login_password">Must not be empty</string>


### PR DESCRIPTION
#### What's this PR do?

Fixes for crashes that were found in v0.0.4. A couple were null pointer exceptions that just needed a null check.

Another involved mismatched data between Northstar and Phoenix. This theoretically shouldn't happen in practice. It only seemed to happen in this case because we were manually deleting data on Northstar staging to test stuff.

That being said, errors can happen, and a bunch of the changes here are to better handle errors that can and probably will arise.

#### Code details
##### GetInterestGroupTitleTask.java
If the `taxonomy_term` endpoint isn't available for one reason or another, this previously used to crash because the error wasn't handled. Now we're showing a Toast message.

##### UploadAvatarTask.java
Same deal here but with profile photo uploading.

##### CampaignSignUpTask.java
We similarly don't want to crash on any errors that happen here. The task's error status is saved along with the pager position the request comes from.

##### CampaignFragment.java
The updates to the task are utilized here. We don't move onto the campaign detail screen until a signup comes back successfully. We also show a progress bar while that request is in progress.

#### Relevant bugs
https://www.fabric.io/do-something/android/apps/org.dosomething.letsdothis/issues?build=0.0.4%20(1)&status=open&event_type=all&time=all