### PR TITLE
Modified build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ brandon_reg.otf
 proxima_nova_bold.otf
 proxima_nova_reg.otf
 
-# Fabric
+# Secrets
 app/fabric.properties
+app/secrets.properties

--- a/README.md
+++ b/README.md
@@ -2,17 +2,36 @@
 
 ## Development
 
-#### secrets.xml
+#### secrets.properties
 
-Make sure to also add a __secrets.xml__ file to the __app/src/main/res/values__ folder for your local development and build boxes to set secret values needed by the app.
+You will need to add a __secrets.properties__ file to the __app/__ folder. This file will include
+the keys required to access our Northstar API and 3rd party services.
+
+Your file should look similar to the following code block. Consult the
+[documentation](https://github.com/DoSomething/ServerConfig/wiki/3.0-Mobile-app:-Let's-Do-This)
+what values should go in here.
 
 ```
-<resources>
- <string name="facebook_app_id">FACEBOOK APP ID HERE</string>
- <string name="parse_app_id">PARSE APP ID HERE</string>
- <string name="parse_client_key">PARSE CLIENT KEY HERE</string>
- <string name="api_key">NORTHSTAR API KEY HERE</string>
-</resources>
+# Secret ids and keys
+
+# Fabric - build distribution and Crashlytics
+FabricApiKey=FABRIC API KEY HERE
+
+# Facebook App Credentials
+FacebookAppIdProduction=FACEBOOK PRODUCTION APP ID HERE
+FacebookAppIdDebug=FACEBOOK TEST APP ID HERE
+
+# Parse - push notifications
+ParseAppId=PARSE APP ID HERE
+ParseClientKey=PARSE CLIENT KEY HERE
+
+# Northstar - user API
+NorthstarAppIdDebug=NORTHSTAR STAGING APP ID HERE
+NorthstarApiKeyDebug=NORTHSTAR STAGING API KEY HERE
+NorthstarAppIdThor=NORTHSTAR THOR APP ID HERE
+NorthstarApiKeyThor=NORTHSTAR THOR API KEY HERE
+NorthstarAppIdProduction=NORTHSTAR PRODUCTION APP ID HERE
+NorthstarApiKeyProduction=NORTHSTAR PRODUCTION API KEY HERE
 ```
 
 #### fabric.properties

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 #### secrets.properties
 
 You will need to add a __secrets.properties__ file to the __app/__ folder. This file will include
-the keys required to access our Northstar API and 3rd party services.
+the keys required to access our Northstar API and other 3rd party services.
 
 Your file should look similar to the following code block. Consult the
 [documentation](https://github.com/DoSomething/ServerConfig/wiki/3.0-Mobile-app:-Let's-Do-This)
-what values should go in here.
+to find out what values should go in here.
 
 ```
 # Secret ids and keys
@@ -36,7 +36,7 @@ NorthstarApiKeyProduction=NORTHSTAR PRODUCTION API KEY HERE
 
 #### fabric.properties
 
-With the addition of Fabric, you'll also likely need to add a __fabric.properties__ file to the __app/__ folder in order to successfully build.
+To support Fabric, you will also need to add a __fabric.properties__ file to the __app/__ folder.
 
 ```
 apiSecret=FABRIC SECRET HERE
@@ -45,4 +45,4 @@ apiKey=FABRIC KEY HERE
 
 #### Fonts
 
-Font files need to be included in the __app/src/main/assets/fonts__ folder. See the [README](https://github.com/DoSomething/LetsDoThis-Android/blob/master/app/src/main/assets/fonts/README.md) for more info.
+Font files need to be included in the __app/src/main/assets/fonts__ folder. See the fonts [README](https://github.com/DoSomething/LetsDoThis-Android/blob/master/app/src/main/assets/fonts/README.md) for more info.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,21 @@ repositories {
     maven { url 'https://maven.fabric.io/public' }
 }
 
+Properties secrets = new Properties();
+FileInputStream fis = new FileInputStream("app/secrets.properties");
+secrets.load(fis);
+
+def FABRIC_API_KEY = secrets.getProperty("FabricApiKey") ?: "Need to set FabricApiKey in app/secrets.properties";
+def FACEBOOK_APP_ID_PROD = secrets.getProperty("FacebookAppIdProduction") ?: "Need to set FacebookAppIdProduction in app/secrets.properties";
+def FACEBOOK_APP_ID_DEBUG = secrets.getProperty("FacebookAppIdDebug") ?: "Need to set FacebookAppIdDebug in app/secrets.properties";
+def PARSE_APP_ID = secrets.getProperty("ParseAppId") ?: "Need to set ParseAppId in app/secrets.properties";
+def PARSE_CLIENT_KEY = secrets.getProperty("ParseClientKey") ?: "Need to set ParseClientKey in app/secrets.properties";
+def NORTHSTAR_APP_ID_DEBUG = secrets.getProperty("NorthstarAppIdDebug") ?: "Need to set NorthstarAppIdDebug in app/secrets.properties";
+def NORTHSTAR_APP_ID_THOR = secrets.getProperty("NorthstarAppIdThor") ?: "Need to set NorthstarAppIdThor in app/secrets.properties";
+def NORTHSTAR_APP_ID_PROD = secrets.getProperty("NorthstarAppIdProduction") ?: "Need to set NorthstarAppIdProduction in app/secrets.properties";
+def NORTHSTAR_API_KEY_DEBUG = secrets.getProperty("NorthstarApiKeyDebug") ?: "Need to set NorthstarApiKeyDebug in app/secrets.properties";
+def NORTHSTAR_API_KEY_THOR = secrets.getProperty("NorthstarApiKeyThor") ?: "Need to set NorthstarApiKeyThor in app/secrets.properties";
+def NORTHSTAR_API_KEY_PROD = secrets.getProperty("NorthstarApiKeyProduction") ?: "Need to set NorthstarApiKeyProduction in app/secrets.properties";
 
 android {
     compileSdkVersion 22
@@ -25,10 +40,29 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "0.0.4"
+        resValue "string", "fabric_api_key", FABRIC_API_KEY
+        resValue "string", "facebook_app_id", FACEBOOK_APP_ID_PROD
+        resValue "string", "parse_app_id", PARSE_APP_ID
+        resValue "string", "parse_client_key", PARSE_CLIENT_KEY
+        resValue "string", "northstar_app_id", NORTHSTAR_APP_ID_PROD
+        resValue "string", "northstar_api_key", NORTHSTAR_API_KEY_PROD
     }
     buildTypes {
+        debug {
+            debuggable true
+            resValue "string", "facebook_app_id", FACEBOOK_APP_ID_DEBUG
+            resValue "string", "northstar_app_id", NORTHSTAR_APP_ID_DEBUG
+            resValue "string", "northstar_api_key", NORTHSTAR_API_KEY_DEBUG
+        }
+        internal {
+            debuggable true
+            signingConfig signingConfigs.debug
+            resValue "string", "facebook_app_id", FACEBOOK_APP_ID_DEBUG
+            resValue "string", "northstar_app_id", NORTHSTAR_APP_ID_THOR
+            resValue "string", "northstar_api_key", NORTHSTAR_API_KEY_THOR
+        }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         packagingOptions {
@@ -67,7 +101,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.3.2'
     provided 'com.intellij:annotations:9.0.4'
     
-    compile 'com.android.support:recyclerview-v7:21.0.0'
+    compile 'com.android.support:recyclerview-v7:22.0.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
 
     compile 'com.facebook.android:facebook-android-sdk:4.0.0'

--- a/app/src/main/java/org/dosomething/letsdothis/data/InterestGroup.java
+++ b/app/src/main/java/org/dosomething/letsdothis/data/InterestGroup.java
@@ -6,21 +6,10 @@ import org.dosomething.letsdothis.R;
  * Created by izzyoji :) on 6/23/15.
  */
 public enum InterestGroup {
-    A(R.string.interest_0, BuildConfig.DEBUG
-            ? 667
-            : 1300),
-
-    B(R.string.interest_1, BuildConfig.DEBUG
-            ? 668
-            : 1301),
-
-    C(R.string.interest_2, BuildConfig.DEBUG
-            ? 669
-            : 1302),
-
-    D(R.string.interest_3, BuildConfig.DEBUG
-            ? 670
-            : 1303);
+    A(R.string.interest_0, 1300, 1300, 667),
+    B(R.string.interest_1, 1301, 1301, 668),
+    C(R.string.interest_2, 1302, 1302, 669),
+    D(R.string.interest_3, 1303, 1303, 670);
 
     // Initial display name resource id
     public int nameResId;
@@ -28,8 +17,25 @@ public enum InterestGroup {
     // Group term id
     public int id;
 
-    InterestGroup(int nameResId, int id) {
+    /**
+     * Constructor
+     *
+     * @param nameResId int String resource id for this group's default name
+     * @param prodId int Term id on the production server
+     * @param thorId int Term id on the thor server
+     * @param qaId int Term id on the qa server
+     */
+    InterestGroup(int nameResId, int prodId, int thorId, int qaId) {
         this.nameResId = nameResId;
-        this.id = id;
+
+        if (BuildConfig.BUILD_TYPE.equals("release")) {
+            this.id = prodId;
+        }
+        else if (BuildConfig.BUILD_TYPE.equals("internal")) {
+            this.id = thorId;
+        }
+        else {
+            this.id = qaId;
+        }
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/DoSomethingAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/DoSomethingAPI.java
@@ -1,5 +1,4 @@
 package org.dosomething.letsdothis.network;
-import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.network.models.ResponseCampaignList;
 import org.dosomething.letsdothis.network.models.ResponseCampaignWrapper;
 import org.dosomething.letsdothis.network.models.ResponseReportBack;
@@ -15,12 +14,10 @@ import retrofit.http.Query;
 /**
  * Created by izzyoji :) on 4/20/15.
  */
-public interface DoSomethingAPI
-{
-
-   String BASE_URL = BuildConfig.DEBUG
-        ? "https://staging.dosomething.org/api/v1/"
-        : "https://www.dosomething.org/api/v1/";
+public interface DoSomethingAPI {
+    String PRODUCTION_URL = "https://www.dosomething.org/api/v1/";
+    String THOR_URL = "https://thor.dosomething.org/api/v1";
+    String QA_URL = "https://staging.dosomething.org/api/v1";
 
     @Headers("Content-Type: application/json")
     @GET("/campaigns/{id}.json")

--- a/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
@@ -1,9 +1,10 @@
 package org.dosomething.letsdothis.network;
+import android.content.Context;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.squareup.okhttp.OkHttpClient;
 
-import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.network.deserializers.ResponseCampaignDeserializer;
@@ -39,12 +40,11 @@ public class NetworkHelper
             @Override
             public void intercept(RequestFacade request)
             {
-                String id = BuildConfig.DEBUG
-                        ? "456"
-                        : "android";
-                request.addHeader("X-DS-Application-Id", id);
-                request.addHeader("X-DS-REST-API-Key",
-                                  LDTApplication.getContext().getString(R.string.api_key));
+                Context context = LDTApplication.getContext();
+                String northstarAppId = context.getString(R.string.northstar_app_id);
+                String northstarApiKey = context.getString(R.string.northstar_api_key);
+                request.addHeader("X-DS-Application-Id", northstarAppId);
+                request.addHeader("X-DS-REST-API-Key", northstarApiKey);
             }
         };
 

--- a/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.squareup.okhttp.OkHttpClient;
 
+import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.network.deserializers.ResponseCampaignDeserializer;
@@ -78,22 +79,42 @@ public class NetworkHelper
         return okHttpClient;
     }
 
-    public static DoSomethingAPI getDoSomethingAPIService()
-    {
+    public static DoSomethingAPI getDoSomethingAPIService() {
+        String baseUrl;
+        if (BuildConfig.BUILD_TYPE.equals("release")) {
+            baseUrl = DoSomethingAPI.PRODUCTION_URL;
+        }
+        else if (BuildConfig.BUILD_TYPE.equals("internal")) {
+            baseUrl = DoSomethingAPI.THOR_URL;
+        }
+        else {
+            baseUrl = DoSomethingAPI.QA_URL;
+        }
+
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(ResponseCampaign.class, new ResponseCampaignDeserializer<ResponseCampaign>())
                 .setDateFormat(JSON_DATE_FORMAT_DO_SOMETHING).create();
         GsonConverter gsonConverter = new GsonConverter(gson);
         return getRequestAdapterBuilder().setConverter(gsonConverter)
-                .setEndpoint(DoSomethingAPI.BASE_URL).build().create(DoSomethingAPI.class);
+                .setEndpoint(baseUrl).build().create(DoSomethingAPI.class);
     }
 
-    public static NorthstarAPI getNorthstarAPIService()
-    {
+    public static NorthstarAPI getNorthstarAPIService() {
+        String baseUrl;
+        if (BuildConfig.BUILD_TYPE.equals("release")) {
+            baseUrl = NorthstarAPI.PRODUCTION_URL;
+        }
+        else if (BuildConfig.BUILD_TYPE.equals("internal")) {
+            baseUrl = NorthstarAPI.THOR_URL;
+        }
+        else {
+            baseUrl = NorthstarAPI.QA_URL;
+        }
+
         Gson gson = new GsonBuilder().setDateFormat(JSON_DATE_FORMAT_NORTHSTAR).create();
         GsonConverter gsonConverter = new GsonConverter(gson);
         return getRequestAdapterBuilder().setConverter(gsonConverter)
-                .setEndpoint(NorthstarAPI.BASE_URL).build().create(NorthstarAPI.class);
+                .setEndpoint(baseUrl).build().create(NorthstarAPI.class);
     }
 
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
@@ -1,5 +1,4 @@
 package org.dosomething.letsdothis.network;
-import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.data.User;
 import org.dosomething.letsdothis.network.models.ParseInstallationRequest;
 import org.dosomething.letsdothis.network.models.RequestCampaignSignup;
@@ -39,12 +38,10 @@ import retrofit.mime.TypedInput;
 /**
  * Created by izzyoji :) on 4/14/15.
  */
-public interface NorthstarAPI
-{
-
-    String BASE_URL = BuildConfig.DEBUG
-            ? "https://northstar-qa.dosomething.org/v1"
-            : "https://northstar.dosomething.org/v1";
+public interface NorthstarAPI {
+    String PRODUCTION_URL = "https://northstar.dosomething.org/v1";
+    String THOR_URL = "https://northstar-thor.dosomething.org/v1";
+    String QA_URL = "https://northstar-qa.dosomething.org/v1";
 
     @FormUrlEncoded
     @Headers("Accept: application/json")


### PR DESCRIPTION
#### What's this PR do?

This PR essentially adds support to use Thor as another server to query against.

Doing this resulted in a bit of refactoring to how URLs and interest group IDs get assigned. Instead of a **secrets.xml** file to keep our secret values, this PR now necessitates that app id and api key information be included in a **secrets.properties** file that doesn't get committed into the repository.

**build.gradle**

A new "internal" build variant was added with the intent of it being used for internal/DS test builds. The build file reads values out of **secrets.properties** and assigns them to auto-generated string resource values. In this way we can set the different URLs and IDs that need to be used in the different server environments.

This can be seen in practice in **InterestGroup.java** for interest group IDs and **NetworkHelper.java** for API URLs.

