### PR TITLE
Sets the default message for the "Share Photo" action

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseRbData.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseRbData.java
@@ -4,52 +4,62 @@ import org.dosomething.letsdothis.data.ReportBack;
 /**
  * Created by toidiu on 7/9/15.
  */
-public class ResponseRbData
-{
+public class ResponseRbData {
     public Wrapper data;
 
-    public static class Wrapper
-    {
-        private RBItems reportback_data;
+    public static class Wrapper {
+        private RBData reportback_data;
 
-        public RBItems getReportback_data()
-        {
+        public RBData getReportback_data() {
             return reportback_data;
         }
     }
 
-    public static class RBItems
-    {
-        public  String id;
-        private Items  reportback_items;
+    public static class RBData {
+        // Report back ID
+        public String id;
 
-        public Items getReportback_items()
-        {
+        // Reported quantity of action taken
+        public String quantity;
+
+        // Individual reportback photo submissions
+        private Items reportback_items;
+
+        public Items getReportback_items() {
             return reportback_items;
         }
     }
 
-    public static class Items
-    {
+    public static class Items {
         private ReportBack data[];
 
-        public ReportBack[] getData()
-        {
+        public ReportBack[] getData() {
             return data;
         }
     }
 
-    public static ReportBack[] getRbList(ResponseRbData response)
-    {
+    public static ReportBack[] getRbList(ResponseRbData response) {
         ReportBack[] data;
-        try
-        {
+        try {
             data = response.data.getReportback_data().getReportback_items().getData();
         }
-        catch(Throwable e)
-        {
+        catch (Throwable e) {
             data = new ReportBack[0];
         }
         return data;
+    }
+
+    /**
+     * Return reported quantity, if any
+     *
+     * @return String RBData.quantity
+     */
+    public String getQuantity() {
+        if (data == null || data.getReportback_data() == null) {
+            return null;
+        }
+        else {
+            return data.getReportback_data().quantity;
+        }
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/RbShareDataTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/RbShareDataTask.java
@@ -27,41 +27,46 @@ import co.touchlab.android.threading.eventbus.EventBusExt;
 /**
  * Created by toidiu on 4/16/15.
  */
-public class RbShareDataTask extends BaseNetworkErrorHandlerTask
-{
-    private final Campaign campaign;
-    public        File     file;
+public class RbShareDataTask extends BaseNetworkErrorHandlerTask {
+    // Campaign to get user's activity for
+    private final Campaign mCampaign;
+
+    // Reportback photo file path
+    public File mFile;
+
+    // User-reported quantity in the reportback
+    public String mQuantity;
 
     public RbShareDataTask(Campaign campaign)
     {
-        this.campaign = campaign;
+        mCampaign = campaign;
     }
 
     @Override
-    protected void run(Context context) throws Throwable
-    {
+    protected void run(Context context) throws Throwable {
+
         String sessionToken = AppPrefs.getInstance(context).getSessionToken();
         ResponseRbData response = NetworkHelper.getNorthstarAPIService()
-                .getRbData(sessionToken, campaign.id);
+                .getRbData(sessionToken, mCampaign.id);
 
+        // Get reported quantity
+        mQuantity = response.getQuantity();
+
+        // Get photo file path. Download it if we don't have it yet.
         ReportBack[] list = ResponseRbData.getRbList(response);
-        if(list.length > 0)
-        {
+        if (list.length > 0) {
             ReportBack reportBack = list[list.length - 1];
 
             String name = "rb_" + response.data
                     .getReportback_data().id + "item_" + reportBack.id + ".jpg";
-            if((getFile(name)).exists())
-            {
-                this.file = getFile(name);
+            if((getFile(name)).exists()) {
+                mFile = getFile(name);
             }
-            else
-            {
-                this.file = downloadAndSaveTile(name, getInputStream(reportBack.getImagePath()));
+            else {
+                mFile = downloadAndSaveTile(name, getInputStream(reportBack.getImagePath()));
             }
         }
-        else
-        {
+        else {
             Toast.makeText(context, "Sorry, something got misplaced.", Toast.LENGTH_SHORT).show();
         }
     }
@@ -112,7 +117,7 @@ public class RbShareDataTask extends BaseNetworkErrorHandlerTask
     }
 
     public Campaign getCampaign() {
-        return campaign;
+        return mCampaign;
     }
 
     @Override

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/RbShareDataTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/RbShareDataTask.java
@@ -111,6 +111,10 @@ public class RbShareDataTask extends BaseNetworkErrorHandlerTask
         return inputStream;
     }
 
+    public Campaign getCampaign() {
+        return campaign;
+    }
+
     @Override
     protected void onComplete(Context context)
     {

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -370,14 +370,23 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(RbShareDataTask task)
-    {
-        if(task.file != null && task.file.exists())
-        {
+    public void onEventMainThread(RbShareDataTask task) {
+        if (task.mFile != null && task.mFile.exists()) {
             Intent share = new Intent(Intent.ACTION_SEND);
-            share.setType("image/*");
-            Uri uri = Uri.fromFile(task.file);
+            share.setType("text/plain");
+
+            // Set default subject and text body
+            share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
+            String defaultMessage = String.format(getString(R.string.share_reportback_message),
+                    task.getCampaign().verb,
+                    task.mQuantity,
+                    task.getCampaign().noun);
+            share.putExtra(Intent.EXTRA_TEXT, defaultMessage);
+
+            // Add file
+            Uri uri = Uri.fromFile(task.mFile);
             share.putExtra(Intent.EXTRA_STREAM, uri);
+
             startActivity(share);
         }
     }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/GroupActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/GroupActivity.java
@@ -254,11 +254,11 @@ public class GroupActivity extends BaseActivity implements GroupAdapter.GroupAda
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(RbShareDataTask task)
     {
-        if(task.file != null && task.file.exists())
+        if(task.mFile != null && task.mFile.exists())
         {
             Intent share = new Intent(Intent.ACTION_SEND);
             share.setType("image/*");
-            Uri uri = Uri.fromFile(task.file);
+            Uri uri = Uri.fromFile(task.mFile);
             share.putExtra(Intent.EXTRA_STREAM, uri);
             startActivity(share);
         }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -324,7 +324,7 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(RbShareDataTask task) {
-        if (task.file != null && task.file.exists()) {
+        if (task.mFile != null && task.mFile.exists()) {
             Intent share = new Intent(Intent.ACTION_SEND);
             share.setType("text/plain");
 
@@ -332,12 +332,12 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
             share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
             String defaultMessage = String.format(getString(R.string.share_reportback_message),
                     task.getCampaign().verb,
-                    task.getCampaign().userReportBack.quantity,
+                    task.mQuantity,
                     task.getCampaign().noun);
             share.putExtra(Intent.EXTRA_TEXT, defaultMessage);
 
             // Add file
-            Uri uri = Uri.fromFile(task.file);
+            Uri uri = Uri.fromFile(task.mFile);
             share.putExtra(Intent.EXTRA_STREAM, uri);
 
             startActivity(share);

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -323,14 +323,23 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(RbShareDataTask task)
-    {
-        if(task.file != null && task.file.exists())
-        {
+    public void onEventMainThread(RbShareDataTask task) {
+        if (task.file != null && task.file.exists()) {
             Intent share = new Intent(Intent.ACTION_SEND);
-            share.setType("image/*");
+            share.setType("text/plain");
+
+            // Set default subject and text body
+            share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
+            String defaultMessage = String.format(getString(R.string.share_reportback_message),
+                    task.getCampaign().verb,
+                    task.getCampaign().userReportBack.quantity,
+                    task.getCampaign().noun);
+            share.putExtra(Intent.EXTRA_TEXT, defaultMessage);
+
+            // Add file
             Uri uri = Uri.fromFile(task.file);
             share.putExtra(Intent.EXTRA_STREAM, uri);
+
             startActivity(share);
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,9 @@
     <string name="share_invite">I want you to join the %1$s campaign with me, here\'s the code:
         %2$s.
     </string>
+    <string name="share_reportback_message">Bam! I %1$s %2$s %3$s on the Let\'s Do This app. Want to do more
+        un-boring stuff with me? https://play.google.com/store/apps/details?id=org.dosomething.letsdothis
+    </string>
     <string name="done">Done</string>
     <string name="error_avatar_upload">There was an error uploading your photo</string>
     <string name="error_code_length">An invite code should be 15 characters long!</string>
@@ -125,8 +128,8 @@
     <string name="search_for_group">Search For Group</string>
     <string name="join_this_group">Join This Group</string>
     <string name="intro_title_1">Stop Being Bored</string>
-    <string name="intro_desc_1">Are you into sports? Crafting? Whatever your interest, you can do
-        fun stuff and social good at the same time</string>
+    <string name="intro_desc_1">Are you into sports? Crafting? Whatever your interests, you can do
+        fun stuff and social good at the same time.</string>
     <string name="intro_title_2">Prove It</string>
     <string name="intro_desc_2">Submit and share photos of yourself in action -- and see other
         people\'s photos too. #picsoritdidnthappen</string>


### PR DESCRIPTION
#### What's this PR do?

There's a Share Photo button that shows up when you've reported back on a campaign. It lets you share the photo you reported back with to your social networks.

This had previously been implemented to only share the image. The changes in this PR additionally set the default message which includes the reported quantity and action noun and verbs.

#### Particular areas to be concerned with

- **ResponseRbData.RBData** - in addition to the renaming, the `quantity` field is also added here so that we're able to access that later when we build the default message

- **HubFragment.java and CampaignDetailsActivity.java** - The changes here are pretty straightforward in order to allow text to be included in the Intent along with the photo. The type was change to `text/plain` and `Intent.EXTRA_SUBJECT` and `Intent.EXTRA_TEXT` were added to the Intent.

#### Megaspec

4.1.3