### PR TITLE
Fix to properly display profile photo on reportback details screen

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/data/User.java
+++ b/app/src/main/java/org/dosomething/letsdothis/data/User.java
@@ -34,6 +34,12 @@ public class User
     public String password;
     public String source;
 
+    // @TODO Sometimes this User class is used to receive responses from the server. The
+    // ReportBackDetailsTask is one example. In those cases, the profile photo actually is returned
+    // in the "photo" parameter. A future refactor could be to consolidate the use of this and
+    // the "avatarPath" variable that also saves to the database.
+    public String photo;
+
     public User()
     {
     }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackDetailsActivity.java
@@ -164,9 +164,14 @@ public class ReportBackDetailsActivity extends BaseActivity
         }
 
         // User profile photo
-        if (reportBack.user.avatarPath != null && !reportBack.user.avatarPath.isEmpty()) {
-            Picasso.with(this).load(reportBack.user.avatarPath)
+        if (reportBack.user.photo != null && !reportBack.user.photo.isEmpty()) {
+            Picasso.with(this).load(reportBack.user.photo)
                     .placeholder(R.drawable.default_profile_photo)
+                    .resizeDimen(R.dimen.friend_avatar, R.dimen.friend_avatar)
+                    .into(avatar);
+        }
+        else {
+            Picasso.with(this).load(R.drawable.default_profile_photo)
                     .resizeDimen(R.dimen.friend_avatar, R.dimen.friend_avatar)
                     .into(avatar);
         }

--- a/app/src/main/res/layout/item_report_back_expanded.xml
+++ b/app/src/main/res/layout/item_report_back_expanded.xml
@@ -23,7 +23,6 @@
         <org.dosomething.letsdothis.ui.views.CircleImageView
             android:layout_marginLeft="@dimen/padding_small"
             android:id="@+id/avatar"
-            android:src="@drawable/default_profile_photo"
             android:layout_width="@dimen/friend_avatar"
             android:layout_height="@dimen/friend_avatar"
             app:background_color="@color/gray"


### PR DESCRIPTION
#### What's this PR do?
Correctly displays the profile photo of the user who submitted the reportback on the reportback detail screen. Previously it would also display Roger.

#### Where should the reviewer start?
- **item_report_back_expanded.xml**: While the photo's being downloaded, it would show Roger for a split second. Removing it here so it doesn't show.
- **ReportBackDetailsActivity.java**: Uses `photo` instead of `avatarPath`. Also loads up Roger if there is no provided photo.
- **User.java**: This class doesn't seem to be meant to be used as an API response handler, but in the case of ReportBackDetailsTask, it does. And instead of the photo being available under `avatarPath` it's in `photo`. Pretty confusing having both of them in that class, so we'll probably want to fix this up later to consolidate the two vars.