### PR TITLE
Crash fixes

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
@@ -54,10 +54,8 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
     }
 
     @Override
-    protected boolean handleError(Context context, Throwable throwable)
-    {
-        super.handleError(context, throwable);
-        return false;
+    protected boolean handleError(Context context, Throwable throwable) {
+        return super.handleError(context, throwable);
     }
 
     @Override

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -371,24 +371,27 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(RbShareDataTask task) {
-        if (task.mFile != null && task.mFile.exists()) {
-            Intent share = new Intent(Intent.ACTION_SEND);
-            share.setType("text/plain");
+        Intent share = new Intent(Intent.ACTION_SEND);
+        share.setType("text/plain");
 
-            // Set default subject and text body
-            share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
+        share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
+
+        // Add a default message if we have the data we need
+        if (task.getCampaign() != null) {
             String defaultMessage = String.format(getString(R.string.share_reportback_message),
                     task.getCampaign().verb,
                     task.mQuantity,
                     task.getCampaign().noun);
             share.putExtra(Intent.EXTRA_TEXT, defaultMessage);
+        }
 
-            // Add file
+        // Attach the file if we have it
+        if (task.mFile != null && task.mFile.exists()) {
             Uri uri = Uri.fromFile(task.mFile);
             share.putExtra(Intent.EXTRA_STREAM, uri);
-
-            startActivity(share);
         }
+
+        startActivity(share);
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -324,24 +324,27 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(RbShareDataTask task) {
-        if (task.mFile != null && task.mFile.exists()) {
-            Intent share = new Intent(Intent.ACTION_SEND);
-            share.setType("text/plain");
+        Intent share = new Intent(Intent.ACTION_SEND);
+        share.setType("text/plain");
 
-            // Set default subject and text body
-            share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
+        share.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.app_name));
+
+        // Add a default message if we have the data we need
+        if (task.getCampaign() != null) {
             String defaultMessage = String.format(getString(R.string.share_reportback_message),
                     task.getCampaign().verb,
                     task.mQuantity,
                     task.getCampaign().noun);
             share.putExtra(Intent.EXTRA_TEXT, defaultMessage);
+        }
 
-            // Add file
+        // Attach the file if we have it
+        if (task.mFile != null && task.mFile.exists()) {
             Uri uri = Uri.fromFile(task.mFile);
             share.putExtra(Intent.EXTRA_STREAM, uri);
-
-            startActivity(share);
         }
+
+        startActivity(share);
     }
 
     @SuppressWarnings("UnusedDeclaration")


### PR DESCRIPTION
#### What's this PR do?
- Gracefully handles errors that could happen if there was slowness or other sorts of server errors while trying to pull campaign data for the main feed. Basically just throws a Toast error and doesn't crash.
- Handles any errors that might come from the "Share Photo" process. If any required data like the photo or campaign info wasn't successfully retrieved, we just remove that info from the share, but still allow the share intent to be open. Otherwise, people would just be tapping on the "Share Photo" button and nothing would happen.

#### The code
- **UpdateInterestGroupCampaignTask.java**: This just lets the parent class handle the error. And that class does `return true` in all cases, so we won't crash.
- **CampaignDetailsActivity.java** and **HubFragment.java**: This is the Share Photo handling stuff.

#### What are the relevant tickets?
Closes #109 
Closes #110