### PR TITLE
Adds link to feedback form in Settings

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
@@ -38,6 +38,7 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
         initRate();
         initLogout();
         initChangePhoto();
+        initFeedback();
         initSuggestionLink();
 
         mTracker = ((LDTApplication)getActivity().getApplication()).getDefaultTracker();
@@ -112,6 +113,24 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
                 });
     }
 
+    private void initFeedback() {
+        findPreference(getString(R.string.pref_feedback))
+                .setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                    @Override
+                    public boolean onPreferenceClick(Preference preference) {
+                        final String url = "https://docs.google.com/a/dosomething.org/forms/d/1KUWQgfuoKpUXg7uuurXSgYQ3RCuxwNVSrGeb_kDRqf8/viewform";
+                        Intent intent = new Intent(Intent.ACTION_VIEW);
+                        intent.setData(Uri.parse(url));
+                        startActivity(intent);
+
+                        AnalyticsUtils.sendEvent(mTracker, AnalyticsUtils.CATEGORY_BEHAVIOR,
+                                AnalyticsUtils.ACTION_TAP_FEEDBACK_FORM);
+
+                        return true;
+                    }
+                });
+    }
+
     private void initSuggestionLink() {
         findPreference(getString(R.string.pref_suggestion_link))
                 .setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
@@ -122,7 +141,7 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
                         startActivity(intent);
 
                         AnalyticsUtils.sendEvent(mTracker, AnalyticsUtils.CATEGORY_BEHAVIOR,
-                                AnalyticsUtils.ACTION_TAP_FEEDBACK_FORM);
+                                AnalyticsUtils.ACTION_TAP_IDEAS_FORM);
 
                         return true;
                     }

--- a/app/src/main/java/org/dosomething/letsdothis/utils/AnalyticsUtils.java
+++ b/app/src/main/java/org/dosomething/letsdothis/utils/AnalyticsUtils.java
@@ -34,6 +34,7 @@ public class AnalyticsUtils {
     public static final String ACTION_SHARE_PHOTO = "share photo";
     public static final String ACTION_LOG_OUT = "log out";
     public static final String ACTION_TAP_FEEDBACK_FORM = "tap on feedback form";
+    public static final String ACTION_TAP_IDEAS_FORM = "tap on ideas form";
     public static final String ACTION_TAP_PRIVACY_POLICY = "tap on privacy policy";
     public static final String ACTION_TAP_REVIEW_APP_BUTTON = "tap on review app button";
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="notification_friend">notification_friend</string>
     <string name="notification_campaign">notification_campaign</string>
     <string name="notification_pref">Notification Preferences</string>
+    <string name="pref_feedback">Give Us Your Feedback</string>
     <string name="pref_suggestion_link">Have your own ideas? Fill out this form and let us know.</string>
     <string name="expired_already">Oof. This action has expired. Let’s freshen things up.</string>
     <string name="max_kudos">99+</string>

--- a/app/src/main/res/xml/preference_general.xml
+++ b/app/src/main/res/xml/preference_general.xml
@@ -43,10 +43,17 @@
             android:defaultValue="true"
             android:key="@string/rate"
             android:title="@string/rate"/>
+    </org.dosomething.letsdothis.ui.views.typeface.preferences.CustomPreferenceCategory>
 
+    <!--
+        Feedback
+    -->
+    <org.dosomething.letsdothis.ui.views.typeface.preferences.CustomPreferenceCategory>
         <org.dosomething.letsdothis.ui.views.typeface.preferences.CustomPreference
-            android:enabled="false"
-            android:title="We'll never interrupt you to ask for ratings."/>
+            android:enabled="true"
+            android:defaultValue="true"
+            android:key="@string/pref_feedback"
+            android:title="@string/pref_feedback"/>
     </org.dosomething.letsdothis.ui.views.typeface.preferences.CustomPreferenceCategory>
 
     <!--


### PR DESCRIPTION
#### What's this PR do?

It adds a link in the Settings screen to our app feedback google form. Also...

- removes the "We'll never interrupt you to ask for ratings." line
- New Google Analytic tracking event. The feedback form added here will use the "tap on feedback form" event, and the UGC ideas form will use "tap on ideas form" for its event string

What the Setting screen now looks like on Android.
![screen shot 2015-10-27 at 3 36 43 pm](https://cloud.githubusercontent.com/assets/696595/10770253/9530d482-7cc0-11e5-8b15-e3dadc18f0b6.png)