### PR TITLE
v0.0.8 merge

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 22
         versionCode 1
-        versionName "0.0.7"
+        versionName "0.0.8"
         resValue "string", "fabric_api_key", FABRIC_API_KEY
         resValue "string", "facebook_app_id", FACEBOOK_APP_ID_PROD
         resValue "string", "parse_app_id", PARSE_APP_ID

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
@@ -27,14 +27,19 @@ public class CampaignSignUpTask extends Task {
     // Set to true if an error occurs
     private boolean mHasError;
 
+    // Set to true if this is a new signup
+    private boolean mIsNewSignup;
+
     public CampaignSignUpTask(int campaignId) {
         this.mCampaignId = campaignId;
+        this.mIsNewSignup = false;
     }
 
     public CampaignSignUpTask(int campaignId, int pagerPosition) {
         this.mCampaignId = campaignId;
         this.mPagerPosition = pagerPosition;
         this.mHasError = false;
+        this.mIsNewSignup = false;
     }
 
     //
@@ -54,8 +59,12 @@ public class CampaignSignUpTask extends Task {
 
     @Override
     protected void onComplete(Context context) {
-        EventBusExt.getDefault().post(this);
         super.onComplete(context);
+        EventBusExt.getDefault().post(this);
+
+        if (mIsNewSignup) {
+            Toast.makeText(context, R.string.campaign_signup_confirmation, Toast.LENGTH_SHORT).show();
+        }
     }
 
     @Override
@@ -75,12 +84,14 @@ public class CampaignSignUpTask extends Task {
             campaignActions.campaignId = mCampaignId;
             campaignActions.signUpId = ResponseCampaignSignUp.getSignUpId(response);
             CampaignActions.save(context, campaignActions);
+
+            this.mIsNewSignup = true;
         }
     }
 
     @Override
     protected boolean handleError(Context context, Throwable throwable) {
-        Toast.makeText(context, context.getString(R.string.error_signup), Toast.LENGTH_SHORT).show();
+        Toast.makeText(context, R.string.error_signup, Toast.LENGTH_SHORT).show();
         mHasError = true;
         return true;
     }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/LogoutTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/LogoutTask.java
@@ -3,7 +3,6 @@ import android.content.Context;
 
 import com.facebook.login.LoginManager;
 
-import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.utils.AppPrefs;
 
@@ -12,25 +11,31 @@ import co.touchlab.android.threading.eventbus.EventBusExt;
 /**
  * Created by izzyoji :) on 4/30/15.
  */
-public class LogoutTask extends BaseNetworkErrorHandlerTask
-{
-    private String sessionToken;
+public class LogoutTask extends BaseNetworkErrorHandlerTask {
 
     @Override
-    protected void run(Context context) throws Throwable
-    {
-        //FIXME switch to using persisted task
-        LoginManager.getInstance().logOut();
-        EventBusExt.getDefault().post(this);
+    protected void onComplete(Context context) {
+        super.onComplete(context);
 
-        sessionToken = AppPrefs.getInstance(context).getSessionToken();
-        NetworkHelper.getNorthstarAPIService().logout(sessionToken);
-        AppPrefs.getInstance(context).logout();
+        EventBusExt.getDefault().post(this);
     }
 
     @Override
-    protected boolean handleError(Context context, Throwable throwable)
-    {
+    protected void run(Context context) throws Throwable {
+        LoginManager.getInstance().logOut();
+
+        // Get current token to logout with
+        String sessionToken = AppPrefs.getInstance(context).getSessionToken();
+
+        // Clear local cache of the token
+        AppPrefs.getInstance(context).logout();
+
+        // Logout from API
+        NetworkHelper.getNorthstarAPIService().logout(sessionToken);
+    }
+
+    @Override
+    protected boolean handleError(Context context, Throwable throwable) {
         return true;
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/ReportbackUploadTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/ReportbackUploadTask.java
@@ -3,8 +3,10 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Base64;
+import android.widget.Toast;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.models.RequestReportback;
 import org.dosomething.letsdothis.network.models.ResponseSubmitReportBack;
@@ -60,10 +62,11 @@ public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
     }
 
     @Override
-    protected void onComplete(Context context)
-    {
+    protected void onComplete(Context context) {
         super.onComplete(context);
         EventBusExt.getDefault().post(this);
+
+        Toast.makeText(context, R.string.campaign_reportback_confirmation, Toast.LENGTH_SHORT).show();
     }
 
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
@@ -28,9 +28,12 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
     // Resulting campaigns
     public List<Campaign> campaigns;
 
-    public UpdateInterestGroupCampaignTask(int interestGroupId)
-    {
+    // True if an error was encountered during the task
+    private boolean mHasError;
+
+    public UpdateInterestGroupCampaignTask(int interestGroupId) {
         this.interestGroupId = interestGroupId;
+        this.mHasError = false;
     }
 
     @Override
@@ -55,7 +58,10 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
 
     @Override
     protected boolean handleError(Context context, Throwable throwable) {
-        return super.handleError(context, throwable);
+        super.handleError(context, throwable);
+        mHasError = true;
+
+        return true;
     }
 
     @Override
@@ -63,6 +69,10 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
     {
         EventBusExt.getDefault().post(this);
         super.onComplete(context);
+    }
+
+    public boolean hasError() {
+        return mHasError;
     }
 
     public static class IdQuery implements BaseTaskQueue.QueueQuery

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
@@ -51,15 +51,15 @@ public class UploadAvatarTask extends Task
     }
 
     @Override
-    protected boolean handleError(Context context, Throwable e)
-    {
-        Toast.makeText(context, context.getString(R.string.error_avatar_upload), Toast.LENGTH_SHORT).show();
+    protected boolean handleError(Context context, Throwable e) {
+        Toast.makeText(context, R.string.error_avatar_upload, Toast.LENGTH_SHORT).show();
         return true;
     }
 
     @Override
-    protected void onComplete(Context context)
-    {
+    protected void onComplete(Context context) {
         super.onComplete(context);
+
+        Toast.makeText(context, R.string.change_photo_confirmation, Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -246,7 +246,6 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
                 Campaign clickedCampaign = adapter.getCampaign();
                 if (selectedImageUri != null) {
-Toast.makeText(CampaignDetailsActivity.this, R.string.error_photo_select, Toast.LENGTH_SHORT).show();
                     Intent cropIntent = PhotoCropActivity.getResultIntent(
                             this,
                             selectedImageUri.toString(),

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -275,11 +275,15 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             }
 
             // Report back campaign name and details
-            reportBackViewHolder.title.setText(currentCampaign.title);
+
+            final String title = currentCampaign != null ? currentCampaign.title : "";
+            final String noun = currentCampaign != null ? currentCampaign.noun: "";
+            final String verb = currentCampaign != null ? currentCampaign.verb : "";
+            reportBackViewHolder.title.setText(title);
             reportBackViewHolder.caption.setText(reportBack.caption);
 
             String impactText = String.format("%s %s %s", String.valueOf(reportBack.reportback.quantity),
-                    currentCampaign.noun, currentCampaign.verb);
+                    noun, verb);
             reportBackViewHolder.impact.setText(impactText);
 
             // Click listeners on the user name and user photo

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
@@ -128,7 +128,7 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
         recyclerView.setLayoutManager(layoutManager);
 
         EventBusExt.getDefault().register(this);
-        dbCampaignRefresh();
+        campaignRefresh();
     }
 
     @Override
@@ -220,14 +220,13 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
     }
 
 
-    public void dbCampaignRefresh()
+    public void campaignRefresh()
     {
         adapter.clear();
         currentRbQueryStatus = BaseReportBackListTask.STATUS_PROMOTED;
         currentPage = 0;
         totalPages = 0;
-        DatabaseHelper.defaultDatabaseQueue(getActivity())
-                .execute(new DbInterestGroupCampaignListTask(findGroupId()));
+        getCampaignQueue().execute(new UpdateInterestGroupCampaignTask(findGroupId()));
         refreshProgressBar();
     }
 

--- a/app/src/main/res/layout/activity_fragment_recycler.xml
+++ b/app/src/main/res/layout/activity_fragment_recycler.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android/apk/res-auto"
+    xmlns:tool="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <ProgressBar
         android:id="@+id/progress"
@@ -20,5 +23,62 @@
         android:layout_height="match_parent"
         android:layout_below="@+id/progress"
         android:background="@color/white"/>
+
+    <LinearLayout
+        android:id="@+id/error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:paddingLeft="@dimen/padding_xxlarge"
+        android:paddingRight="@dimen/padding_xxlarge"
+        android:paddingTop="@dimen/padding_xxlarge"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <org.dosomething.letsdothis.ui.views.CircleImageView
+            android:layout_width="@dimen/hub_avatar_height"
+            android:layout_height="@dimen/hub_avatar_height"
+            android:src="@drawable/default_profile_photo"
+            app:border_color="@color/white"
+            app:border_width="@dimen/padding_tiny"
+            app:draw_border="true"/>
+
+        <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="@dimen/padding_small"
+            android:paddingRight="@dimen/padding_small"
+            android:paddingTop="@dimen/padding_medium"
+            android:text="@string/error_network_main_title"
+            android:textColor="@color/silverChalice"
+            android:textSize="@dimen/text_33"
+            android:textStyle="bold"
+            app:typeface="brandon_bold"
+            tool:text="@string/error_network_main_title" />
+
+        <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:padding="@dimen/padding_small"
+            android:text="@string/error_network_main_body"
+            android:textColor="@color/black_70"
+            android:textSize="@dimen/text_33"
+            app:typeface="brandon_regular"
+            tool:text="@string/error_network_main_body"/>
+
+        <org.dosomething.letsdothis.ui.views.typeface.CustomButton
+            android:id="@+id/retry_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/padding_small"
+            android:text="@string/error_network_main_button"
+            android:textAllCaps="true"
+            android:textColor="@color/white"
+            app:typeface="brandon_bold"
+            tool:text="@string/error_network_main_button"/>
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,7 @@
         #picsoritdidnthappen
     </string>
     <string name="campaign_reportback_confirmation">Stunning! You submitted your action for approval. </string>
-    <string name="campaign_signup_confirmation">Niiiiice. You signed up for %1$s.</string>
+    <string name="campaign_signup_confirmation">Niiiiice. You\'re signed up for this campaign.</string>
     <string name="campaign_signup_failed">Oops! Our bad. Looks like there was an issue with that
         request. We\'re looking into it now!
     </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,10 @@
     <string name="error_interest_group_titles">There was an error getting campaign info</string>
     <string name="error_login_phone_email">Must not be empty</string>
     <string name="error_login_password">Must not be empty</string>
+    <string name="error_network_main_title">There\'s nothing here!</string>
+    <string name="error_network_main_body">Either we can\'t connect to the internet or there are no
+        actions available right now.</string>
+    <string name="error_network_main_button">Try Again</string>
     <string name="error_photo_select">Error loading the photo</string>
     <string name="error_registration_email">We need a valid email</string>
     <string name="error_registration_first_name">We need your first name</string>


### PR DESCRIPTION
- Basic Toast confirmation messages on user actions: campaign signup, reportback and changing profile photo
- Changed logic on how campaign data is retrieved. Used to pull from local db first, but now pulls from server. There's probably some optimization that can be done here, but it'll at least fix up problems we would see otherwise with campaign content not being updated even if it has been on the server.
- Fail whale type of screen added when there's an error (server or network) pulling campaign data from the server
- LogoutTask mini-refactor - should fix problems that could come from failed logouts and then trying to log back in