### PR TITLE
v0.0.9

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 22
         versionCode 1
-        versionName "0.0.8"
+        versionName "0.0.9"
         resValue "string", "fabric_api_key", FABRIC_API_KEY
         resValue "string", "facebook_app_id", FACEBOOK_APP_ID_PROD
         resValue "string", "parse_app_id", PARSE_APP_ID

--- a/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
@@ -55,11 +55,17 @@ public interface NorthstarAPI {
     ResponseLogin loginWithEmail(@Field("email") String email, @Field(
             "password") String password) throws NetworkException;
 
-    @Headers("Content-Type: application/json")
+    @Headers({
+            "Content-Type: application/json",
+            "Accept: application/json"
+    })
     @POST("/users?create_drupal_user=1")
     ResponseRegister registerWithEmail(@Body User user) throws NetworkException;
 
-    @Headers("Content-Type: application/json")
+    @Headers({
+            "Content-Type: application/json",
+            "Accept: application/json"
+    })
     @POST("/users?create_drupal_user=1")
     ResponseRegister registerWithMobile(@Body User user) throws NetworkException;
 

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
@@ -10,6 +10,8 @@ import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.models.ParseInstallationRequest;
 import org.dosomething.letsdothis.utils.AppPrefs;
 
+import retrofit.RetrofitError;
+
 /**
  * Created by toidiu on 4/16/15.
  */
@@ -17,6 +19,7 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
 {
     private final String mPhoneEmail;
     protected final String mPassword;
+    private String mErrorMessage;
 
     protected BaseRegistrationTask(String email, String password)
     {
@@ -24,6 +27,7 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
                 ? null
                 : email;
         mPassword = password;
+        mErrorMessage = null;
     }
 
     protected void loginUser(Context context, User user) throws Throwable
@@ -70,6 +74,41 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
     protected boolean matchesEmail(String email)
     {
         return Patterns.EMAIL_ADDRESS.matcher(email).matches();
+    }
+
+    @Override
+    protected boolean handleError(Context context, Throwable throwable) {
+        if (throwable instanceof RetrofitError) {
+            RetrofitError retrofitError = (RetrofitError) throwable;
+            RegistrationError regError = (RegistrationError) retrofitError.getBodyAs(RegistrationError.class);
+            mErrorMessage = regError.error.message;
+
+            return true;
+        }
+        else {
+            return super.handleError(context, throwable);
+        }
+    }
+
+    /**
+     * Returns an error message received from an error response. Returns null if none.
+     *
+     * @return String
+     */
+    public String getErrorMessage() {
+        return mErrorMessage;
+    }
+
+    /**
+     * Data structure of error returned from a registration attempt.
+     */
+    class RegistrationError {
+        class RegistrationErrorBody {
+            public int code;
+            public String message;
+        }
+
+        public RegistrationErrorBody error;
     }
 
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
@@ -56,15 +56,14 @@ public class RegisterTask extends BaseRegistrationTask
 
                 AppPrefs.getInstance(context).setSessionToken(response.data.session_token);
                 loginUser(context, user);
-                //FIXME: need to get the session token here
             }
         }
     }
 
     @Override
-    protected void onComplete(Context context)
-    {
+    protected void onComplete(Context context) {
         super.onComplete(context);
+
         EventBusExt.getDefault().post(this);
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -280,25 +280,21 @@ public class RegisterActivity extends BaseActivity
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(RegisterTask task)
-    {
+    public void onEventMainThread(RegisterTask task) {
         AppPrefs prefs = AppPrefs.getInstance(this);
-        if (prefs.getCurrentUserId() != null && prefs.getAvatarPath() != null)
-        {
+        if (prefs.getCurrentUserId() != null && prefs.getAvatarPath() != null) {
             TaskQueue.loadQueueDefault(RegisterActivity.this).execute(
                     new UploadAvatarTask(prefs.getCurrentUserId(), prefs.getAvatarPath())
             );
         }
 
-        if (prefs.isLoggedIn())
-        {
+        if (prefs.isLoggedIn()) {
             broadcastLogInSuccess(this);
             startActivity(MainActivity.getLaunchIntent(this));
         }
-        else
-        {
-            Snackbar snackbar = Snackbar
-                    .make(findViewById(R.id.snack), R.string.fail_register, Snackbar.LENGTH_SHORT);
+        else {
+            String message = task.getErrorMessage() != null ? task.getErrorMessage() : getString(R.string.fail_register);
+            Snackbar snackbar = Snackbar.make(findViewById(R.id.snack), message, Snackbar.LENGTH_SHORT);
             View snackBarView = snackbar.getView();
             snackBarView.setBackgroundColor(getResources().getColor(R.color.snack_error));
             snackbar.show();

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
@@ -166,7 +166,7 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
     public void onCampaignClicked(int campaignId, boolean alreadySignedUp)
     {
         if (!alreadySignedUp) {
-            TaskQueue.loadQueueDefault(getActivity()).execute(new CampaignSignUpTask(campaignId));
+            TaskQueue.loadQueueDefault(getActivity()).execute(new CampaignSignUpTask(campaignId, mPagerPosition));
         }
         else {
             startActivity(CampaignDetailsActivity.getLaunchIntent(getActivity(), campaignId));
@@ -313,7 +313,6 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
     {
         if(findGroupId() == task.interestGroupId)
         {
-            // @TODO seems like campaigns won't get updated on app if they're changed on the server?
             if(task.campList.isEmpty())
             {
                 getCampaignQueue()

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
@@ -137,7 +137,7 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
                     @Override
                     public boolean onPreferenceClick(Preference preference) {
                         Intent intent = new Intent(Intent.ACTION_VIEW);
-                        intent.setData(Uri.parse("https://www.dosomething.org/campaigns/submit-your-idea"));
+                        intent.setData(Uri.parse("https://www.dosomething.org/us/about/submit-your-campaign-idea"));
                         startActivity(intent);
 
                         AnalyticsUtils.sendEvent(mTracker, AnalyticsUtils.CATEGORY_BEHAVIOR,

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/SettingsFragment.java
@@ -2,6 +2,8 @@ package org.dosomething.letsdothis.ui.fragments;
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
@@ -40,6 +42,7 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
         initChangePhoto();
         initFeedback();
         initSuggestionLink();
+        displayVersionName();
 
         mTracker = ((LDTApplication)getActivity().getApplication()).getDefaultTracker();
     }
@@ -146,6 +149,19 @@ public class SettingsFragment extends PreferenceFragment implements ConfirmDialo
                         return true;
                     }
                 });
+    }
+
+    private void displayVersionName() {
+        String packageName = getActivity().getPackageName();
+        try {
+            PackageInfo packageInfo = getActivity().getPackageManager().getPackageInfo(packageName, 0);
+            String version = getString(R.string.pref_version_text, packageInfo.versionName);
+
+            findPreference(getString(R.string.pref_version_key)).setTitle(version);
+        }
+        catch (PackageManager.NameNotFoundException e) {
+            ; // Just don't display anything I guess? Or find some way to log it so we can see it.
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,7 +150,7 @@
     <string name="intro_title_2">Prove It</string>
     <string name="intro_desc_2">Submit and share photos of yourself in action -- and see other
         people\'s photos too. #picsoritdidnthappen</string>
-    <string name="fail_register">Register failed</string>
+    <string name="fail_register">Registration failed</string>
     <string name="fail_login">Your username or password was incorrect.</string>
     <string name="success_login">Login successful</string>
     <string name="success_register">Register successful</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,8 @@
     <string name="notification_pref">Notification Preferences</string>
     <string name="pref_feedback">Give Us Your Feedback</string>
     <string name="pref_suggestion_link">Have your own ideas? Fill out this form and let us know.</string>
+    <string name="pref_version_key">pref_version_key</string>
+    <string name="pref_version_text">v%1$s</string>
     <string name="expired_already">Oof. This action has expired. Let’s freshen things up.</string>
     <string name="max_kudos">99+</string>
     <string name="log_in_with_facebook">Log in with Facebook</string>

--- a/app/src/main/res/xml/preference_general.xml
+++ b/app/src/main/res/xml/preference_general.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <!--FIXME: implement settings-->
+
     <!--
         ACCOUNT
     -->
@@ -65,5 +65,12 @@
             android:key="@string/pref_suggestion_link"
             android:title="@string/pref_suggestion_link"/>
     </org.dosomething.letsdothis.ui.views.typeface.preferences.CustomPreferenceCategory>
+
+    <!--
+        Version name
+    -->
+    <org.dosomething.letsdothis.ui.views.typeface.preferences.CustomPreference
+        android:enabled="false"
+        android:key="@string/pref_version_key"/>
 
 </PreferenceScreen>


### PR DESCRIPTION
- Fixes a bug where the progress bar would continue to show after a failed campaign signup (like from poor network or server error)
- Fixes link to the user submitted campaigns website
- Registration errors will be more descriptive because it'll use the message from the server now. If the email you tried to register with is taken, we'll forward that message up to the UI.
- The version name is now displayed on the Settings screen. Should make it easier for people to check and tell us if problems do arise for a particular version.