### PR TITLE
Rename DoSomethingAPI to PhoenixAPI

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
@@ -29,7 +29,7 @@ import retrofit.converter.GsonConverter;
 public class NetworkHelper
 {
     public static final String JSON_DATE_FORMAT_NORTHSTAR    = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    public static final String JSON_DATE_FORMAT_DO_SOMETHING = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    public static final String JSON_DATE_FORMAT_PHOENIX      = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     public static final int    CONNECT_TIMEOUT               = 45;
     public static final int    READ_TIMEOUT                  = 30;
 
@@ -79,24 +79,24 @@ public class NetworkHelper
         return okHttpClient;
     }
 
-    public static DoSomethingAPI getDoSomethingAPIService() {
+    public static PhoenixAPI getPhoenixAPIService() {
         String baseUrl;
         if (BuildConfig.BUILD_TYPE.equals("release")) {
-            baseUrl = DoSomethingAPI.PRODUCTION_URL;
+            baseUrl = PhoenixAPI.PRODUCTION_URL;
         }
         else if (BuildConfig.BUILD_TYPE.equals("internal")) {
-            baseUrl = DoSomethingAPI.PRODUCTION_URL;
+            baseUrl = PhoenixAPI.PRODUCTION_URL;
         }
         else {
-            baseUrl = DoSomethingAPI.QA_URL;
+            baseUrl = PhoenixAPI.QA_URL;
         }
 
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(ResponseCampaign.class, new ResponseCampaignDeserializer<ResponseCampaign>())
-                .setDateFormat(JSON_DATE_FORMAT_DO_SOMETHING).create();
+                .setDateFormat(JSON_DATE_FORMAT_PHOENIX).create();
         GsonConverter gsonConverter = new GsonConverter(gson);
         return getRequestAdapterBuilder().setConverter(gsonConverter)
-                .setEndpoint(baseUrl).build().create(DoSomethingAPI.class);
+                .setEndpoint(baseUrl).build().create(PhoenixAPI.class);
     }
 
     public static NorthstarAPI getNorthstarAPIService() {

--- a/app/src/main/java/org/dosomething/letsdothis/network/PhoenixAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/PhoenixAPI.java
@@ -14,7 +14,7 @@ import retrofit.http.Query;
 /**
  * Created by izzyoji :) on 4/20/15.
  */
-public interface DoSomethingAPI {
+public interface PhoenixAPI {
     String PRODUCTION_URL = "https://www.dosomething.org/api/v1/";
     String THOR_URL = "https://thor.dosomething.org/api/v1";
     String QA_URL = "https://staging.dosomething.org/api/v1";

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseReportBackListTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseReportBackListTask.java
@@ -44,7 +44,7 @@ public abstract class BaseReportBackListTask extends BaseNetworkErrorHandlerTask
 
     @Override
     protected void run(Context context) throws Throwable {
-        ResponseReportBackList response = NetworkHelper.getDoSomethingAPIService().reportBackList(
+        ResponseReportBackList response = NetworkHelper.getPhoenixAPIService().reportBackList(
             status, campaignIds, REQUEST_COUNT, false, page);
 
         if (response.error != null) {

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignDetailsTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignDetailsTask.java
@@ -26,7 +26,7 @@ public class CampaignDetailsTask extends BaseNetworkErrorHandlerTask
     @Override
     protected void run(Context context) throws Throwable
     {
-        ResponseCampaignWrapper response = NetworkHelper.getDoSomethingAPIService()
+        ResponseCampaignWrapper response = NetworkHelper.getPhoenixAPIService()
                 .campaign(campaignId);
         campaign = ResponseCampaign.getCampaign(response.data);
 

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GetInterestGroupTitleTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GetInterestGroupTitleTask.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.widget.Toast;
 
 import org.dosomething.letsdothis.R;
-import org.dosomething.letsdothis.network.DoSomethingAPI;
+import org.dosomething.letsdothis.network.PhoenixAPI;
 import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.models.ResponseTaxonomyTerm;
 
@@ -35,7 +35,7 @@ public class GetInterestGroupTitleTask extends BaseNetworkErrorHandlerTask {
 
     @Override
     protected void run(Context context) throws Throwable {
-        DoSomethingAPI api = NetworkHelper.getDoSomethingAPIService();
+        PhoenixAPI api = NetworkHelper.getPhoenixAPIService();
 
         for (int i = 0; i < 4; i++) {
             ResponseTaxonomyTerm response = api.taxonomyTerm(mGroupIds[i]);

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GetUserCampaignsTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GetUserCampaignsTask.java
@@ -90,7 +90,7 @@ public class GetUserCampaignsTask extends BaseNetworkErrorHandlerTask {
 
         // Populate the currentCampaigns list
         if (!campaignIds.isEmpty()) {
-            ResponseCampaignList responseCampaignList = NetworkHelper.getDoSomethingAPIService()
+            ResponseCampaignList responseCampaignList = NetworkHelper.getPhoenixAPIService()
                     .campaignListByIds(campaignIds);
             List<Campaign> campaigns = ResponseCampaignList.getCampaigns(responseCampaignList);
 
@@ -129,7 +129,7 @@ public class GetUserCampaignsTask extends BaseNetworkErrorHandlerTask {
         if (!pastIds.isEmpty())
         {
             pastIds = pastIds.substring(0, pastIds.length() - 1);
-            ResponseCampaignList responseCampaignList = NetworkHelper.getDoSomethingAPIService()
+            ResponseCampaignList responseCampaignList = NetworkHelper.getPhoenixAPIService()
                     .campaignListByIds(pastIds);
             pastCampaignList = ResponseCampaignList.getCampaigns(responseCampaignList);
         }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/GroupTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/GroupTask.java
@@ -51,7 +51,7 @@ public class GroupTask extends Task
         ResponseGroup responseGroup = NetworkHelper.getNorthstarAPIService().group(groupId);
 
         int campaignId = responseGroup.data.campaign_id;
-        ResponseCampaignWrapper responseCampaignWrapper = NetworkHelper.getDoSomethingAPIService()
+        ResponseCampaignWrapper responseCampaignWrapper = NetworkHelper.getPhoenixAPIService()
                                                                        .campaign(campaignId);
 
         campaign = ResponseCampaign.getCampaign(responseCampaignWrapper.data);

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/InvitesTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/InvitesTask.java
@@ -43,7 +43,7 @@ public class InvitesTask extends Task
         }
 
         String campaignIds = StringUtils.join(inviteHashMap.keySet(), ",");
-        ResponseCampaignList responseCampaignList = NetworkHelper.getDoSomethingAPIService()
+        ResponseCampaignList responseCampaignList = NetworkHelper.getPhoenixAPIService()
                                                                  .campaignListByIds(campaignIds);
         List<Campaign> campaigns = ResponseCampaignList.getCampaigns(responseCampaignList);
 

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/ReportBackDetailsTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/ReportBackDetailsTask.java
@@ -23,7 +23,7 @@ public class ReportBackDetailsTask extends BaseNetworkErrorHandlerTask
     @Override
     protected void run(Context context) throws Throwable
     {
-        ResponseReportBack response = NetworkHelper.getDoSomethingAPIService()
+        ResponseReportBack response = NetworkHelper.getPhoenixAPIService()
                                                    .reportBack(reportBackId);
         reportBack = ResponseReportBack.getReportBack(response);
     }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UpdateInterestGroupCampaignTask.java
@@ -40,7 +40,7 @@ public class UpdateInterestGroupCampaignTask extends BaseNetworkErrorHandlerTask
     protected void run(Context context) throws Throwable {
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
         String currentDate = df.format(new Date());
-        ResponseCampaignList response = NetworkHelper.getDoSomethingAPIService()
+        ResponseCampaignList response = NetworkHelper.getPhoenixAPIService()
                 .campaignList(interestGroupId, currentDate);
         campaigns = ResponseCampaignList.getCampaigns(response);
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/MainActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/MainActivity.java
@@ -176,7 +176,7 @@ public class MainActivity extends BaseActivity implements SetTitleListener, Repl
                     responses[0] = gson.toJson(responseGroup);
 
                     ResponseCampaignWrapper responseCampaignWrapper = NetworkHelper
-                            .getDoSomethingAPIService().campaign(responseGroup.data.campaign_id);
+                            .getPhoenixAPIService().campaign(responseGroup.data.campaign_id);
                     responses[1] = gson.toJson(responseCampaignWrapper);
 
                 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/InvitesFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/InvitesFragment.java
@@ -132,7 +132,7 @@ public class InvitesFragment extends Fragment implements InvitesAdapter.InviteAd
                         responses[0] = gson.toJson(responseGroup);
 
                         ResponseCampaignWrapper responseCampaignWrapper = NetworkHelper
-                                .getDoSomethingAPIService()
+                                .getPhoenixAPIService()
                                 .campaign(responseGroup.data.campaign_id);
                         responses[1] = gson.toJson(responseCampaignWrapper);
 


### PR DESCRIPTION
#### What's this PR do?
Functionally nothing should've changed. This should just rename the DoSomethingAPI service and references to it to PhoenixAPI. It matches how we talk about the API internally and clarifies that it's specifically Phoenix and not a general DoSomething API.

#### How was this tested?
Run on an emulator against staging. Ensured all areas that the app makes calls to Phoenix behave normally:
- **main activity feed** with interest group names, campaigns per group and gallery of reportback photos
- **individual campaign detail page** with campain info and gallery of reportback photos

#### Relevant issues?
Closes #126 