### PR TITLE
Snackbar confirmation messages

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
@@ -57,14 +57,14 @@ public class CampaignSignUpTask extends Task {
         return mHasError;
     }
 
+    public boolean isNewSignup() {
+        return mIsNewSignup;
+    }
+
     @Override
     protected void onComplete(Context context) {
         super.onComplete(context);
         EventBusExt.getDefault().post(this);
-
-        if (mIsNewSignup && !mHasError) {
-            Toast.makeText(context, R.string.campaign_signup_confirmation, Toast.LENGTH_SHORT).show();
-        }
     }
 
     @Override

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/ReportbackUploadTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/ReportbackUploadTask.java
@@ -3,10 +3,8 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Base64;
-import android.widget.Toast;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.network.NetworkHelper;
 import org.dosomething.letsdothis.network.models.RequestReportback;
 import org.dosomething.letsdothis.network.models.ResponseSubmitReportBack;
@@ -18,8 +16,8 @@ import co.touchlab.android.threading.tasks.TaskQueue;
 /**
  * Created by izzyoji :) on 5/15/15.
  */
-public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
-{
+public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask {
+
     // Reportback request data
     private final RequestReportback mRequest;
 
@@ -32,14 +30,11 @@ public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
     // Set to true if an error occurs
     private boolean mHasError;
 
-
-    public static TaskQueue getQueue(Context context)
-    {
+    public static TaskQueue getQueue(Context context) {
         return TaskQueue.loadQueue(context, "reportBack");
     }
 
-    public static void uploadReport(Context context, RequestReportback req, int campaignId, String filePath)
-    {
+    public static void uploadReport(Context context, RequestReportback req, int campaignId, String filePath) {
         getQueue(context).execute(new ReportbackUploadTask(req, campaignId, filePath));
     }
 
@@ -47,23 +42,26 @@ public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
         this.mRequest = req;
         this.mCampaignId = campaignId;
         this.mFilePath = filePath;
+        this.mHasError = false;
     }
 
     public int getCampaignId() {
         return mCampaignId;
     }
 
+    public boolean hasError() {
+        return mHasError;
+    }
+
     @Override
-    protected void run(Context context) throws Throwable
-    {
+    protected void run(Context context) throws Throwable {
         mRequest.file = base64Encode(mFilePath);
         String sessionToken = AppPrefs.getInstance(context).getSessionToken();
         ResponseSubmitReportBack response = NetworkHelper.getNorthstarAPIService()
                 .submitReportback(sessionToken, mRequest, mCampaignId);
     }
 
-    private String base64Encode(String filePath)
-    {
+    private String base64Encode(String filePath) {
         Bitmap bm = BitmapFactory.decodeFile(filePath);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         bm.compress(Bitmap.CompressFormat.JPEG, 100, baos); //bm is the bitmap object
@@ -74,11 +72,8 @@ public class ReportbackUploadTask extends BaseNetworkErrorHandlerTask
     @Override
     protected void onComplete(Context context) {
         super.onComplete(context);
-        EventBusExt.getDefault().post(this);
 
-        if (!mHasError) {
-            Toast.makeText(context, R.string.campaign_reportback_confirmation, Toast.LENGTH_SHORT).show();
-        }
+        EventBusExt.getDefault().post(this);
     }
 
     @Override

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/UploadAvatarTask.java
@@ -1,11 +1,8 @@
 package org.dosomething.letsdothis.tasks;
 import android.content.Context;
-import android.util.Log;
-import android.widget.Toast;
 
 import com.j256.ormlite.dao.Dao;
 
-import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.DatabaseHelper;
 import org.dosomething.letsdothis.data.User;
 import org.dosomething.letsdothis.network.NetworkHelper;
@@ -20,30 +17,31 @@ import retrofit.mime.TypedFile;
 /**
  * Created by toidiu on 4/16/15.
  */
-public class UploadAvatarTask extends Task
-{
+public class UploadAvatarTask extends Task {
+
     private String filePath;
     private String userId;
     public  User   user;
     private boolean mHasError;
 
-    public UploadAvatarTask(String id, String filePath)
-    {
+    public UploadAvatarTask(String id, String filePath) {
         this.userId = id;
         this.filePath = filePath;
         this.mHasError = false;
     }
 
+    public boolean hasError() {
+        return mHasError;
+    }
+
     @Override
-    protected void run(Context context) throws Throwable
-    {
+    protected void run(Context context) throws Throwable {
         File file = new File(filePath);
         Dao<User, String> userDao = DatabaseHelper.getInstance(context).getUserDao();
         user = userDao.queryForId(userId);
         user.avatarPath = "file:" + filePath;
 
         userDao.createOrUpdate(user);
-        EventBusExt.getDefault().post(this);
 
         TypedFile typedFile = new TypedFile("multipart/form-data", file);
         ResponseAvatar response = NetworkHelper.getNorthstarAPIService()
@@ -54,7 +52,6 @@ public class UploadAvatarTask extends Task
 
     @Override
     protected boolean handleError(Context context, Throwable e) {
-        Toast.makeText(context, R.string.error_avatar_upload, Toast.LENGTH_SHORT).show();
         mHasError = true;
         return true;
     }
@@ -63,8 +60,6 @@ public class UploadAvatarTask extends Task
     protected void onComplete(Context context) {
         super.onComplete(context);
 
-        if (!mHasError) {
-            Toast.makeText(context, R.string.change_photo_confirmation, Toast.LENGTH_SHORT).show();
-        }
+        EventBusExt.getDefault().post(this);
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -92,7 +92,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         int campaignId = getIntent().getIntExtra(EXTRA_CAMPAIGN_ID, -1);
         boolean isNewSignup = getIntent().getBooleanExtra(EXTRA_IS_NEW_SIGNUP, false);
         if (isNewSignup) {
-            showSignupSuccessSnackbar();
+            showSnackbarSuccessMessage(R.string.campaign_signup_confirmation);
         }
 
         // Determine if user is signed up for this campaign
@@ -299,11 +299,10 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     /**
-     * Show the snackbar with the signup success message.
+     * Show the snackbar with a success message.
      */
-    private void showSignupSuccessSnackbar() {
-        Snackbar snackbar = Snackbar.make(findViewById(R.id.snack),
-                R.string.campaign_signup_confirmation, Snackbar.LENGTH_LONG);
+    private void showSnackbarSuccessMessage(int stringResId) {
+        Snackbar snackbar = Snackbar.make(findViewById(R.id.snack), stringResId, Snackbar.LENGTH_LONG);
         View snackBarView = snackbar.getView();
         snackBarView.setBackgroundColor(getResources().getColor(R.color.cerulean_1));
         snackbar.show();
@@ -341,6 +340,10 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(ReportbackUploadTask task) {
         refreshCampaign(task.getCampaignId());
+
+        if (!task.hasError()) {
+            showSnackbarSuccessMessage(R.string.campaign_reportback_confirmation);
+        }
     }
 
     @SuppressWarnings("UnusedDeclaration")
@@ -420,7 +423,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         if (!task.hasError()) {
             adapter.refreshOnSignup();
 
-            showSignupSuccessSnackbar();
+            showSnackbarSuccessMessage(R.string.campaign_signup_confirmation);
         }
 
         AnalyticsUtils.sendEvent(mTracker, AnalyticsUtils.CATEGORY_CAMPAIGN,

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -5,12 +5,14 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.Toast;
 
 import com.google.android.gms.analytics.Tracker;
@@ -47,6 +49,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
     //~=~=~=~=~=~=~=~=~=~=~=~=Constants
     public static final String EXTRA_CAMPAIGN_ID = "campaign_id";
+    public static final String EXTRA_IS_NEW_SIGNUP = "new_signup";
     public static final int    SELECT_PICTURE    = 23123;
 
     //~=~=~=~=~=~=~=~=~=~=~=~=Fields
@@ -60,16 +63,21 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     // Google Analytics tracker
     private Tracker mTracker;
 
-    public static Intent getLaunchIntent(Context context, int campaignId)
-    {
+    public static Intent getLaunchIntent(Context context, int campaignId) {
         return new Intent(context, CampaignDetailsActivity.class)
                 .putExtra(EXTRA_CAMPAIGN_ID, campaignId);
     }
 
+    public static Intent getLaunchIntent(Context context, int campaignId, boolean isNewSignup) {
+        return new Intent(context, CampaignDetailsActivity.class)
+                .putExtra(EXTRA_CAMPAIGN_ID, campaignId)
+                .putExtra(EXTRA_IS_NEW_SIGNUP, isNewSignup);
+    }
+
     @Override
-    protected void onCreate(Bundle savedInstanceState)
-    {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         setContentView(R.layout.activity_fragment_quickreturn_recycler);
         EventBusExt.getDefault().register(this);
 
@@ -81,11 +89,14 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-
-        int campaignId = getIntent().getIntExtra(EXTRA_CAMPAIGN_ID, - 1);
-        boolean userIsSignedUp = false;
+        int campaignId = getIntent().getIntExtra(EXTRA_CAMPAIGN_ID, -1);
+        boolean isNewSignup = getIntent().getBooleanExtra(EXTRA_IS_NEW_SIGNUP, false);
+        if (isNewSignup) {
+            showSignupSuccessSnackbar();
+        }
 
         // Determine if user is signed up for this campaign
+        boolean userIsSignedUp = false;
         try {
             if (CampaignActions.queryForId(this, campaignId) != null) {
                 userIsSignedUp = true;
@@ -112,21 +123,18 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @Override
-    protected void onResume()
-    {
+    protected void onResume() {
         super.onResume();
+
         if(TaskQueueHelper
-                .hasTasksOfType(ReportbackUploadTask.getQueue(this), ReportbackUploadTask.class))
-        {
+                .hasTasksOfType(ReportbackUploadTask.getQueue(this), ReportbackUploadTask.class)) {
             adapter.processingUpload();
         }
     }
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item)
-    {
-        switch(item.getItemId())
-        {
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
             case android.R.id.home:
                 onBackPressed();
                 return true;
@@ -167,8 +175,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @Override
-    public void proveClicked()
-    {
+    public void proveClicked() {
         choosePicture();
     }
 
@@ -180,22 +187,19 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @Override
-    public void inviteClicked()
-    {
+    public void inviteClicked() {
         Campaign campaign = adapter.getCampaign();
         startActivity(
                 CampaignInviteActivity.getLaunchIntent(this, campaign.title, campaign.signupGroup));
     }
 
     @Override
-    public void onUserClicked(String id)
-    {
+    public void onUserClicked(String id) {
         startActivity(PublicProfileActivity.getLaunchIntent(this, id));
     }
 
     @Override
-    public void onKudosClicked(ReportBack reportBack, Kudos kudos)
-    {
+    public void onKudosClicked(ReportBack reportBack, Kudos kudos) {
         TaskQueue.loadQueueDefault(this).execute(new SubmitKudosTask(kudos.id, reportBack.id));
     }
 
@@ -212,8 +216,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @Override
-    protected void onDestroy()
-    {
+    protected void onDestroy() {
         EventBusExt.getDefault().unregister(this);
         super.onDestroy();
     }
@@ -269,8 +272,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         }
     }
 
-    public void choosePicture()
-    {
+    public void choosePicture() {
         Intent pickIntent = new Intent(Intent.ACTION_PICK,
                                        android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
         pickIntent.setType("image/*");
@@ -281,8 +283,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         File file = new File(externalFile, "reportBack" + System.currentTimeMillis() + ".jpg");
         takePhotoIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(file));
         imageUri = Uri.parse(file.getAbsolutePath());
-        if(BuildConfig.DEBUG)
-        {
+        if (BuildConfig.DEBUG) {
             Log.d("photo location", imageUri.toString());
         }
 
@@ -293,9 +294,19 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         startActivityForResult(chooserIntent, SELECT_PICTURE);
     }
 
-    private void refreshCampaign(int campaignId)
-    {
+    private void refreshCampaign(int campaignId) {
         TaskQueue.loadQueueDefault(this).execute(new CampaignDetailsTask(campaignId));
+    }
+
+    /**
+     * Show the snackbar with the signup success message.
+     */
+    private void showSignupSuccessSnackbar() {
+        Snackbar snackbar = Snackbar.make(findViewById(R.id.snack),
+                R.string.campaign_signup_confirmation, Snackbar.LENGTH_LONG);
+        View snackBarView = snackbar.getView();
+        snackBarView.setBackgroundColor(getResources().getColor(R.color.cerulean_1));
+        snackbar.show();
     }
 
     /**
@@ -328,8 +339,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(ReportbackUploadTask task)
-    {
+    public void onEventMainThread(ReportbackUploadTask task) {
         refreshCampaign(task.getCampaignId());
     }
 
@@ -339,7 +349,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         boolean isComplete = false;
         boolean isSignedUp = false;
 
-        if(task.campaign != null) {
+        if (task.campaign != null) {
             // Update the view in the adapter
             adapter.updateCampaign(task.campaign);
 
@@ -390,8 +400,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(IndividualCampaignReportBackList task)
-    {
+    public void onEventMainThread(IndividualCampaignReportBackList task) {
         totalPages = task.totalPages;
         currentPage = task.page;
         List<ReportBack> reportBacks = task.reportBacks;
@@ -408,7 +417,11 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(CampaignSignUpTask task) {
-        adapter.refreshOnSignup();
+        if (!task.hasError()) {
+            adapter.refreshOnSignup();
+
+            showSignupSuccessSnackbar();
+        }
 
         AnalyticsUtils.sendEvent(mTracker, AnalyticsUtils.CATEGORY_CAMPAIGN,
                 AnalyticsUtils.ACTION_SUBMIT_SIGNUP, Integer.toString(task.getCampaignId()));

--- a/app/src/main/java/org/dosomething/letsdothis/ui/SettingsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/SettingsActivity.java
@@ -3,13 +3,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.view.MenuItem;
+import android.view.View;
 
 import com.google.android.gms.analytics.Tracker;
 
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.tasks.LogoutTask;
+import org.dosomething.letsdothis.tasks.UploadAvatarTask;
 import org.dosomething.letsdothis.ui.fragments.SetTitleListener;
 import org.dosomething.letsdothis.ui.fragments.SettingsFragment;
 import org.dosomething.letsdothis.ui.views.typeface.CustomToolbar;
@@ -72,6 +75,22 @@ public class SettingsActivity extends BaseActivity implements SetTitleListener
         startActivity(RegisterLoginActivity.getLaunchIntent(this));
 
         AnalyticsUtils.sendEvent(mTracker, AnalyticsUtils.CATEGORY_BEHAVIOR, AnalyticsUtils.ACTION_LOG_OUT);
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public void onEventMainThread(UploadAvatarTask task) {
+        int stringResId = R.string.change_photo_confirmation;
+        int colorResId = R.color.cerulean_1;
+
+        if (task.hasError()) {
+            stringResId = R.string.error_avatar_upload;
+            colorResId = R.color.snack_error;
+        }
+
+        Snackbar snackbar = Snackbar.make(findViewById(R.id.snack), stringResId, Snackbar.LENGTH_LONG);
+        View snackBarView = snackbar.getView();
+        snackBarView.setBackgroundColor(getResources().getColor(colorResId));
+        snackbar.show();
     }
 
     @Override

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CampaignFragment.java
@@ -1,4 +1,5 @@
 package org.dosomething.letsdothis.ui.fragments;
+import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -401,7 +402,9 @@ public class CampaignFragment extends Fragment implements CampaignAdapter.Campai
 
             if (task != null && !task.hasError()) {
                 adapter.userSignedUpForCampaign(task.getCampaignId());
-                startActivity(CampaignDetailsActivity.getLaunchIntent(getActivity(), task.getCampaignId()));
+                Intent i = CampaignDetailsActivity.getLaunchIntent(getActivity(),
+                        task.getCampaignId(), task.isNewSignup());
+                startActivity(i);
 
                 // Log the successful signup to analytics
                 Tracker tracker = ((LDTApplication)getActivity().getApplication()).getDefaultTracker();

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -354,9 +355,16 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public void onEventMainThread(ReportbackUploadTask task)
-    {
+    public void onEventMainThread(ReportbackUploadTask task) {
         refreshUserCampaign();
+
+        if (!task.hasError()) {
+            Snackbar snackbar = Snackbar.make(getView().findViewById(R.id.snack),
+                    R.string.campaign_reportback_confirmation, Snackbar.LENGTH_LONG);
+            View snackBarView = snackbar.getView();
+            snackBarView.setBackgroundColor(getResources().getColor(R.color.cerulean_1));
+            snackbar.show();
+        }
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/app/src/main/res/layout/activity_fragment_quickreturn_recycler.xml
+++ b/app/src/main/res/layout/activity_fragment_quickreturn_recycler.xml
@@ -13,4 +13,11 @@
         android:id="@+id/toolbar"
         layout="@layout/toolbar"/>
 
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/snack"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="bottom">
+    </android.support.design.widget.CoordinatorLayout>
+
 </FrameLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -14,4 +14,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/snack"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true">
+    </android.support.design.widget.CoordinatorLayout>
+
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_avatar_change.xml
+++ b/app/src/main/res/layout/fragment_avatar_change.xml
@@ -1,16 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white">
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_alignParentTop="true"
+        android:indeterminate="true"
+        android:visibility="gone"/>
 
     <org.dosomething.letsdothis.ui.views.CircleImageView
         android:id="@+id/avatar"
         android:layout_width="@dimen/avatar"
         android:layout_height="@dimen/avatar"
-        android:layout_gravity="center_horizontal"
+        android:layout_below="@id/progress"
+        android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/padding_medium"
         android:src="@drawable/ic_action_add"
         app:background_color="@color/porcelain"
@@ -22,9 +31,10 @@
         android:id="@+id/save"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@id/avatar"
         android:layout_marginLeft="@dimen/padding_small"
         android:layout_marginRight="@dimen/padding_small"
         android:text="@string/save_photo"
         app:typeface="brandon_bold"/>
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_recycler.xml
+++ b/app/src/main/res/layout/fragment_recycler.xml
@@ -20,4 +20,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>
 
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/snack"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true">
+    </android.support.design.widget.CoordinatorLayout>
+
 </RelativeLayout>


### PR DESCRIPTION
#### What's this PR do?
Snackbarrrrr confirmation for campaign signup, campaign reportback and profile photo change.

- Toast messages used to be hidden in the Tasks. We're able to take this logic out of there into the specific Fragment or Activity that the messages should show up in now.
- Anywhere a `android.support.design.widget.CoordinatorLayout`widget has gotten added into xml is where a SnackBar is getting used.
- Also added a ProgressBar to the AvatarChangeFragment while a photo is being uploaded.

#### What are the relevant issues?
Closes #130 