### PR TITLE
Hub modifications

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/MainActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/MainActivity.java
@@ -14,7 +14,6 @@ import android.widget.ListView;
 
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.ui.adapters.DrawerListAdapter;
-import org.dosomething.letsdothis.ui.fragments.ActionsFragment;
 import org.dosomething.letsdothis.ui.fragments.CauseListFragment;
 import org.dosomething.letsdothis.ui.fragments.HubFragment;
 import org.dosomething.letsdothis.ui.fragments.NewsFragment;
@@ -147,7 +146,7 @@ public class MainActivity extends BaseActivity implements SetTitleListener, Repl
             }
         }
 
-        replaceCurrentFragment(ActionsFragment.newInstance(), ActionsFragment.TAG);
+        replaceCurrentFragment(CauseListFragment.newInstance(), CauseListFragment.TAG);
     }
 
     /**

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignAdapter.java
@@ -35,10 +35,9 @@ public class CampaignAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     //~=~=~=~=~=~=~=~=~=~=~=~=Constants
     public static final int    VIEW_TYPE_CAMPAIGN           = 0;
     public static final int    VIEW_TYPE_CAMPAIGN_EXPANDED  = 1;
-    public static final int    V_TYPE_CAMP_EXPANDED_EXPIRED = 2;
-    public static final int    VIEW_TYPE_CAMPAIGN_SMALL     = 3;
-    public static final int    VIEW_TYPE_CAMPAIGN_FOOTER    = 4;
-    public static final int    VIEW_TYPE_REPORT_BACK        = 5;
+    public static final int    VIEW_TYPE_CAMPAIGN_SMALL     = 2;
+    public static final int    VIEW_TYPE_CAMPAIGN_FOOTER    = 3;
+    public static final int    VIEW_TYPE_REPORT_BACK        = 4;
     public static final String PLACEHOLDER                  = "placeholder";
 
     private final int shadowColor;
@@ -84,11 +83,6 @@ public class CampaignAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         {
             if(position == selectedPosition)
             {
-                Campaign camp = (Campaign) currentObject;
-                if(TimeUtils.isCampaignExpired(camp))
-                {
-                    return V_TYPE_CAMP_EXPANDED_EXPIRED;
-                }
                 return VIEW_TYPE_CAMPAIGN_EXPANDED;
             }
             else if(selectedPosition != - 1)
@@ -124,10 +118,6 @@ public class CampaignAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 v = LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.item_report_back_square, parent, false);
                 return new ReportBackViewHolder((ReportBackImageView) v);
-            case V_TYPE_CAMP_EXPANDED_EXPIRED:
-                v = LayoutInflater.from(parent.getContext())
-                        .inflate(R.layout.item_campaign_expired_large, parent, false);
-                return new ExpandedExpireCampaignViewHolder(v);
             case VIEW_TYPE_CAMPAIGN_EXPANDED:
                 v = LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.item_campaign_large, parent, false);
@@ -245,53 +235,6 @@ public class CampaignAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 smallCampaignViewHolder.imageView.setColorFilter(new ColorMatrixColorFilter(cm));
             }
         }
-        else if(getItemViewType(position) == V_TYPE_CAMP_EXPANDED_EXPIRED)
-        {
-            final Campaign campaign = (Campaign) dataSet.get(position);
-            final ExpandedExpireCampaignViewHolder viewHolder = (ExpandedExpireCampaignViewHolder) holder;
-
-            viewHolder.title.setText(campaign.title);
-            viewHolder.callToAction.setText(campaign.callToAction);
-
-            int height = resources.getDimensionPixelSize(R.dimen.campaign_height_expanded);
-
-            CharSequence tag = (CharSequence) viewHolder.imageView.getTag();
-
-            if(! TextUtils.equals(campaign.imagePath, tag))
-            {
-                Picasso.with(context).load(campaign.imagePath).resize(0, height)
-                        .into(viewHolder.imageView);
-                viewHolder.imageView.setTag(campaign.imagePath);
-            }
-            viewHolder.imageView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    selectedPosition = -1;
-                    notifyItemChanged(position);
-
-                    campaignAdapterClickListener.onCampaignCollapsed();
-                }
-            });
-
-            final SlantedBackgroundDrawable background = new SlantedBackgroundDrawable(false,
-                                                                                       Color.WHITE,
-                                                                                       shadowColor,
-                                                                                       slantHeight,
-                                                                                       widthOvershoot,
-                                                                                       heightShadowOvershoot);
-            viewHolder.slantedBg.setBackground(background);
-            viewHolder.refreshCopy.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    campaignAdapterClickListener.onNetworkCampaignRefresh();
-                    //FIXME show progress bar
-                }
-            });
-
-            ColorMatrix cm = new ColorMatrix();
-            cm.setSaturation(0);
-            viewHolder.imageView.setColorFilter(new ColorMatrixColorFilter(cm));
-        }
         else if(getItemViewType(position) == VIEW_TYPE_CAMPAIGN_EXPANDED)
         {
             final Campaign campaign = (Campaign) dataSet.get(position);
@@ -345,21 +288,6 @@ public class CampaignAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                     campaignAdapterClickListener.onCampaignClicked(campaign.id, campaign.userIsSignedUp);
                 }
             });
-
-            // If campaign.endTime isn't specified by the server, then don't show the expires label
-            if (campaign.endTime == 0) {
-                viewHolder.expire_label.setVisibility(View.GONE);
-                viewHolder.daysWrapper.setVisibility(View.GONE);
-            }
-            else {
-                viewHolder.expire_label.setVisibility(View.VISIBLE);
-                viewHolder.daysWrapper.setVisibility(View.VISIBLE);
-
-                List<String> campExpTime = TimeUtils.getTimeUntilExpiration(campaign.endTime);
-                int dayInt = Integer.parseInt(campExpTime.get(0));
-                viewHolder.daysLabel.setText(resources.getQuantityString(R.plurals.days, dayInt));
-                viewHolder.days.setText(String.valueOf(dayInt));
-            }
         }
         else if(getItemViewType(position) == VIEW_TYPE_REPORT_BACK)
         {
@@ -480,44 +408,21 @@ public class CampaignAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
         private         View     campaignDetailsWrapper;
         public          TextView callToAction;
         public          TextView expire_label;
-        public          TextView days;
-        public          TextView daysLabel;
         private final   View     slantedBg;
         private final   View     notSignedUp;
         private final   View     alreadySignedUp;
         protected final View     signedupIndicator;
-        protected final View     daysWrapper;
 
         public ExpandedCampaignViewHolder(View itemView)
         {
             super(itemView);
             expire_label = (TextView) itemView.findViewById(R.id.expire_label);
             callToAction = (TextView) itemView.findViewById(R.id.call_to_action);
-            daysWrapper = itemView.findViewById(R.id.days_wrapper);
             slantedBg = itemView.findViewById(R.id.slanted_bg);
             signedupIndicator = itemView.findViewById(R.id.signedup_indicator);
             campaignDetailsWrapper = itemView.findViewById(R.id.campaign_details_wrapper);
             notSignedUp = campaignDetailsWrapper.findViewById(R.id.not_signedup);
             alreadySignedUp = campaignDetailsWrapper.findViewById(R.id.signedup);
-            days = (TextView) itemView.findViewById(R.id.days);
-            daysLabel = (TextView) itemView.findViewById(R.id.days_label);
-        }
-    }
-
-    public static class ExpandedExpireCampaignViewHolder extends CampaignViewHolder
-    {
-        private       View     refreshCopy;
-        public        TextView callToAction;
-        public        TextView expired;
-        private final View     slantedBg;
-
-        public ExpandedExpireCampaignViewHolder(View itemView)
-        {
-            super(itemView);
-            expired = (TextView) itemView.findViewById(R.id.expired_already);
-            callToAction = (TextView) itemView.findViewById(R.id.call_to_action);
-            slantedBg = itemView.findViewById(R.id.slanted_bg);
-            refreshCopy = itemView.findViewById(R.id.refresh_copy);
         }
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/DrawerListAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/DrawerListAdapter.java
@@ -39,7 +39,7 @@ public class DrawerListAdapter extends ArrayAdapter<String> {
             icon.setImageDrawable(resources.getDrawable(R.drawable.ic_news));
         } else if (TextUtils.equals(positionString, resources.getString(R.string.actions))) {
             icon.setImageDrawable(resources.getDrawable(R.drawable.ic_actions));
-        } else if(TextUtils.equals(positionString, resources.getString(R.string.hub))) {
+        } else if (TextUtils.equals(positionString, resources.getString(R.string.hub))) {
             icon.setImageDrawable(resources.getDrawable(R.drawable.ic_hub));
         }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
@@ -20,7 +20,6 @@ import org.dosomething.letsdothis.data.User;
 import org.dosomething.letsdothis.data.UserReportBack;
 import org.dosomething.letsdothis.ui.CampaignDetailsActivity;
 import org.dosomething.letsdothis.ui.ReportBackDetailsActivity;
-import org.dosomething.letsdothis.utils.TimeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -116,10 +115,8 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
     }
 
     @Override
-    public void onBindViewHolder(final RecyclerView.ViewHolder holder, final int position)
-    {
-        if(getItemViewType(position) == VIEW_TYPE_SECTION_TITLE)
-        {
+    public void onBindViewHolder(final RecyclerView.ViewHolder holder, final int position) {
+        if (getItemViewType(position) == VIEW_TYPE_SECTION_TITLE) {
             String s = (String) hubList.get(position);
             SectionTitleViewHolder sectionTitleViewHolder = (SectionTitleViewHolder) holder;
             sectionTitleViewHolder.textView.setText(s);
@@ -262,27 +259,9 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
 
             pastCampaignViewHolder.title.setText(campaign.title);
         }
-        else if(getItemViewType(position) == VIEW_TYPE_EXPIRE)
-        {
-            ExpireViewHolder viewHolder = (ExpireViewHolder) holder;
-
-            // @todo Pretty sure I'm breaking whatever expired logic is going on here with the change
-            // to using mobile_app.dates.end time for campaign end dates. Will want to fix this when
-            // working on Hub stuff.
-            Long expire = TimeUtils.getStartOfNextMonth();
-            List<String> campExpTime = TimeUtils.getTimeUntilExpiration(expire);
-            int dayInt = Integer.parseInt(campExpTime.get(0));
-
-            viewHolder.expire_label.setVisibility(View.VISIBLE);
-            viewHolder.expired.setVisibility(View.GONE);
-            viewHolder.daysWrapper.setVisibility(View.GONE);
-            if (dayInt > 0) {
-                viewHolder.daysWrapper.setVisibility(View.VISIBLE);
-                viewHolder.days.setText(String.valueOf(dayInt));
-            } else {
-                viewHolder.expire_label.setVisibility(View.GONE);
-                viewHolder.expired.setVisibility(View.VISIBLE);
-            }
+        // This is the static label above the list of current campaigns
+        else if(getItemViewType(position) == VIEW_TYPE_EXPIRE) {
+            // @todo Nothing needs to happen here. Should clean this up.
         }
         else if (getItemViewType(position) == VIEW_TYPE_CURRENT_EMPTY) {
             EmptyViewHolder viewHolder = (EmptyViewHolder) holder;
@@ -390,16 +369,12 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         return hubList.size();
     }
 
-    public void processingUpload()
-    {
-        for(int i = 0; i < hubList.size(); i++)
-        {
+    public void processingUpload() {
+        for (int i = 0; i < hubList.size(); i++) {
             Object o = hubList.get(i);
-            if(o instanceof Campaign)
-            {
+            if (o instanceof Campaign) {
                 Campaign campaign = (Campaign) o;
-                if(campaign.id == clickedCampaign.id)
-                {
+                if (campaign.id == clickedCampaign.id) {
                     campaign.showShare = Campaign.UploadShare.UPLOADING;
                     notifyItemChanged(i);
                 }
@@ -412,14 +387,12 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         return clickedCampaign;
     }
 
-    public static class ProfileViewHolder extends RecyclerView.ViewHolder
-    {
+    public static class ProfileViewHolder extends RecyclerView.ViewHolder {
         protected ImageView userImage;
         protected TextView  name;
         protected TextView  userCountry;
 
-        public ProfileViewHolder(View itemView)
-        {
+        public ProfileViewHolder(View itemView) {
             super(itemView);
             this.userImage = (ImageView) itemView.findViewById(R.id.user_image);
             this.name = (TextView) itemView.findViewById(R.id.name);
@@ -427,8 +400,7 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         }
     }
 
-    public static class CurrentCampaignViewHolder extends RecyclerView.ViewHolder
-    {
+    public static class CurrentCampaignViewHolder extends RecyclerView.ViewHolder {
         protected final TextView     title;
         protected final TextView     taglineCaption;
         protected final TextView     count;
@@ -437,8 +409,7 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         protected final ImageView    reportbackImage;
         protected final Button       share;
 
-        public CurrentCampaignViewHolder(View itemView)
-        {
+        public CurrentCampaignViewHolder(View itemView) {
             super(itemView);
             title = (TextView) itemView.findViewById(R.id.title);
             taglineCaption = (TextView) itemView.findViewById(R.id.tagline_caption);
@@ -450,33 +421,20 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder>
         }
     }
 
-    public static class PastCampaignViewHolder extends RecyclerView.ViewHolder
-    {
+    public static class PastCampaignViewHolder extends RecyclerView.ViewHolder {
         protected final ImageView image;
         protected final TextView  title;
 
-        public PastCampaignViewHolder(View itemView)
-        {
+        public PastCampaignViewHolder(View itemView) {
             super(itemView);
             image = (ImageView) itemView.findViewById(R.id.image);
             title = (TextView) itemView.findViewById(R.id.title);
         }
     }
 
-    public static class ExpireViewHolder extends RecyclerView.ViewHolder
-    {
-        public          TextView expired;
-        public          TextView expire_label;
-        protected final TextView days;
-        protected final View     daysWrapper;
-
-        public ExpireViewHolder(View itemView)
-        {
+    public static class ExpireViewHolder extends RecyclerView.ViewHolder {
+        public ExpireViewHolder(View itemView) {
             super(itemView);
-            expire_label = (TextView) itemView.findViewById(R.id.expire_label);
-            expired = (TextView) itemView.findViewById(R.id.expired_already);
-            daysWrapper = itemView.findViewById(R.id.days_wrapper);
-            days = (TextView) itemView.findViewById(R.id.days);
         }
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CauseListFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/CauseListFragment.java
@@ -1,5 +1,6 @@
 package org.dosomething.letsdothis.ui.fragments;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -29,11 +30,20 @@ public class CauseListFragment extends Fragment {
 
     public static final String TAG = CauseListFragment.class.getSimpleName();
 
+    // Listener to set title in the toolbar
+    private SetTitleListener mTitleListener;
+
     // Google Analytics tracker
     private Tracker mTracker;
 
     public static CauseListFragment newInstance() {
         return new CauseListFragment();
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        mTitleListener = (SetTitleListener) getActivity();
     }
 
     @Override
@@ -63,6 +73,8 @@ public class CauseListFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+
+        mTitleListener.setTitle(getResources().getString(R.string.actions));
 
         // Submit screen view to Google Analytics
         AnalyticsUtils.sendScreen(mTracker, AnalyticsUtils.SCREEN_CAUSE_LIST);

--- a/app/src/main/res/layout/item_hub_expire.xml
+++ b/app/src/main/res/layout/item_hub_expire.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tool="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/desertStorm"
@@ -12,64 +11,16 @@
                 android:paddingRight="@dimen/padding_wedge"
                 android:paddingTop="@dimen/padding_small">
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
-            android:id="@+id/expired_already"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/padding_small"
-            android:text="@string/expired_already"
-            android:textColor="@color/gray"
-            android:textSize="@dimen/text_30"
-            android:visibility="gone"
-            app:typeface="brandon_bold"/>
-
         <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
             android:id="@+id/expire_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginRight="@dimen/padding_small"
             android:layout_weight="1"
-            android:text="@string/hub_expire_current"
+            android:text="@string/hub_current_label"
             android:textAllCaps="true"
             android:textColor="@color/dark_gray"
             android:textSize="@dimen/text_36"
             app:typeface="brandon_bold"/>
-
-        <LinearLayout
-            android:id="@+id/days_wrapper"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_weight="1"
-            android:orientation="horizontal">
-
-            <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
-                android:id="@+id/days"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingRight="@dimen/padding_tiny"
-                android:textColor="@color/dark_gray"
-                android:textSize="@dimen/text_large"
-                app:typeface="brandon_bold"
-                tool:text="30"/>
-
-            <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
-                android:id="@+id/days_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/hub_expire_days_left"
-                android:textAllCaps="true"
-                android:textColor="@color/dark_gray"
-                android:textSize="@dimen/text_large"
-                app:typeface="brandon_bold"/>
-
-        </LinearLayout>
-
-    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="cause_relationships_desc">Find volunteer opportunities to promote healthy relationships.</string>
     <string name="cause_sex_desc">Find volunteer opportunities that promote safe consensual sex and combat sexism.</string>
     <string name="cause_violence_desc">Find volunteer opportunities to make your community safer.</string>
-    <string name="hub">Me</string>
+    <string name="hub">Hub</string>
     <string name="hub_empty_action_button">Take Me There</string>
     <string name="hub_empty_public">Hm, we aren\'t able to find any activity for this user.</string>
     <string name="hub_empty_text1">No actions? No problem!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,13 +22,13 @@
     <string name="cause_sex_desc">Find volunteer opportunities that promote safe consensual sex and combat sexism.</string>
     <string name="cause_violence_desc">Find volunteer opportunities to make your community safer.</string>
     <string name="hub">Hub</string>
+    <string name="hub_current_label">Actions I\'m Doing</string>
     <string name="hub_empty_action_button">Take Me There</string>
     <string name="hub_empty_public">Hm, we aren\'t able to find any activity for this user.</string>
     <string name="hub_empty_text1">No actions? No problem!</string>
     <string name="hub_empty_text2">We release 12 new things to do every month, so check your Actions
         tab for what\'s fresh.</string>
-    <string name="hub_expire_current">Current:</string>
-    <string name="hub_expire_days_left">Days Left</string>
+    <string name="hub_past_label">Actions I\'ve Done</string>
     <string name="nav_news">News</string>
     <string name="notifications">Notifications</string>
     <string name="staff_pick">Staff pick</string>


### PR DESCRIPTION
Minor Hub changes towards #169.

- Primarily removing unused code that was meant for the abandoned concept of 12 campaigns that would expire at the end of each month.
- Fixed link for button in an empty Hub view to point to the cause list screen.
- Changed campaign header labels in the Hub to static text instead of displaying the number of days left until campaigns would expire.