### PR TITLE
Thor. x64. Crash fix.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,9 +25,6 @@ def FACEBOOK_APP_ID_PROD = secrets.getProperty("FacebookAppIdProduction") ?: "Ne
 def FACEBOOK_APP_ID_DEBUG = secrets.getProperty("FacebookAppIdDebug") ?: "Need to set FacebookAppIdDebug in app/secrets.properties";
 def PARSE_APP_ID = secrets.getProperty("ParseAppId") ?: "Need to set ParseAppId in app/secrets.properties";
 def PARSE_CLIENT_KEY = secrets.getProperty("ParseClientKey") ?: "Need to set ParseClientKey in app/secrets.properties";
-def NORTHSTAR_APP_ID_DEBUG = secrets.getProperty("NorthstarAppIdDebug") ?: "Need to set NorthstarAppIdDebug in app/secrets.properties";
-def NORTHSTAR_APP_ID_THOR = secrets.getProperty("NorthstarAppIdThor") ?: "Need to set NorthstarAppIdThor in app/secrets.properties";
-def NORTHSTAR_APP_ID_PROD = secrets.getProperty("NorthstarAppIdProduction") ?: "Need to set NorthstarAppIdProduction in app/secrets.properties";
 def NORTHSTAR_API_KEY_DEBUG = secrets.getProperty("NorthstarApiKeyDebug") ?: "Need to set NorthstarApiKeyDebug in app/secrets.properties";
 def NORTHSTAR_API_KEY_THOR = secrets.getProperty("NorthstarApiKeyThor") ?: "Need to set NorthstarApiKeyThor in app/secrets.properties";
 def NORTHSTAR_API_KEY_PROD = secrets.getProperty("NorthstarApiKeyProduction") ?: "Need to set NorthstarApiKeyProduction in app/secrets.properties";
@@ -48,7 +45,6 @@ android {
         resValue "string", "facebook_app_id", FACEBOOK_APP_ID_PROD
         resValue "string", "parse_app_id", PARSE_APP_ID
         resValue "string", "parse_client_key", PARSE_CLIENT_KEY
-        resValue "string", "northstar_app_id", NORTHSTAR_APP_ID_PROD
         resValue "string", "northstar_api_key", NORTHSTAR_API_KEY_PROD
 
         // Enabling multidex support.
@@ -66,14 +62,12 @@ android {
         debug {
             debuggable true
             resValue "string", "facebook_app_id", FACEBOOK_APP_ID_DEBUG
-            resValue "string", "northstar_app_id", NORTHSTAR_APP_ID_DEBUG
             resValue "string", "northstar_api_key", NORTHSTAR_API_KEY_DEBUG
         }
         internal {
             debuggable true
             signingConfig signingConfigs.debug
             resValue "string", "facebook_app_id", FACEBOOK_APP_ID_DEBUG
-            resValue "string", "northstar_app_id", NORTHSTAR_APP_ID_THOR
             resValue "string", "northstar_api_key", NORTHSTAR_API_KEY_THOR
         }
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,13 @@ android {
 
         // Enabling multidex support.
         multiDexEnabled true
+
+        // React Native HACK: exclude 64-bit binaries
+        // @see https://github.com/facebook/react-native/issues/2814
+        // @see https://corbt.com/posts/2015/09/18/mixing-32-and-64bit-dependencies-in-android.html
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
     }
     signingConfigs {
         release {
@@ -88,6 +95,9 @@ android {
             exclude 'META-INF/license.txt'
             exclude 'META-INF/dependencies.txt'
             exclude 'META-INF/LGPL2.1'
+
+            // React Native HACK: excluding 64-bit binaries
+            exclude "lib/arm64-v8a/librealm-jni.so"
         }
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
@@ -42,9 +42,7 @@ public class NetworkHelper
             public void intercept(RequestFacade request)
             {
                 Context context = LDTApplication.getContext();
-                String northstarAppId = context.getString(R.string.northstar_app_id);
                 String northstarApiKey = context.getString(R.string.northstar_api_key);
-                request.addHeader("X-DS-Application-Id", northstarAppId);
                 request.addHeader("X-DS-REST-API-Key", northstarApiKey);
             }
         };
@@ -85,7 +83,7 @@ public class NetworkHelper
             baseUrl = PhoenixAPI.PRODUCTION_URL;
         }
         else if (BuildConfig.BUILD_TYPE.equals("internal")) {
-            baseUrl = PhoenixAPI.PRODUCTION_URL;
+            baseUrl = PhoenixAPI.THOR_URL;
         }
         else {
             baseUrl = PhoenixAPI.QA_URL;
@@ -105,7 +103,7 @@ public class NetworkHelper
             baseUrl = NorthstarAPI.PRODUCTION_URL;
         }
         else if (BuildConfig.BUILD_TYPE.equals("internal")) {
-            baseUrl = NorthstarAPI.PRODUCTION_URL;
+            baseUrl = NorthstarAPI.THOR_URL;
         }
         else {
             baseUrl = NorthstarAPI.QA_URL;

--- a/app/src/main/java/org/dosomething/letsdothis/utils/AnalyticsUtils.java
+++ b/app/src/main/java/org/dosomething/letsdothis/utils/AnalyticsUtils.java
@@ -47,7 +47,7 @@ public class AnalyticsUtils {
     // Screen names
     public static final String SCREEN_CAMPAIGN = "campaign/%1$d/%2$s";
     public static final String SCREEN_CAUSE_LIST = "causes";
-    public static final String SCREEN_CAUSE = "causes/%1$d";
+    public static final String SCREEN_CAUSE = "causes/%1$s";
     public static final String SCREEN_INTEREST_GROUP = "taxonomy_term/%1$d";
     public static final String SCREEN_NEWS = "news";
     public static final String SCREEN_ONBOARDING_1 = "onboarding-first";


### PR DESCRIPTION
#### What's this PR do?
- Internal release builds will now point to Thor again
- Excludes 64-bit binaries from the build because React Native didn't provide one. This would manifest itself in crashes on 64-bit phones that try to open the news feed
- Crash fix when going to any cause screen

#### Relevant issues?

Closes #151 (hopefully)
Closes #173 