### PR TITLE
Display a ProgressDialog while a sign in or register call is in progress

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/LoginActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/LoginActivity.java
@@ -1,4 +1,5 @@
 package org.dosomething.letsdothis.ui;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -32,6 +33,9 @@ public class LoginActivity extends BaseActivity
 
     // Google Analytics tracker
     private Tracker mTracker;
+
+    // Progress dialog while login is in progress
+    private ProgressDialog mProgressDialog;
 
     public static Intent getLaunchIntent(Context context)
     {
@@ -110,6 +114,9 @@ public class LoginActivity extends BaseActivity
                 if (isValid) {
                     TaskQueue.loadQueueDefault(LoginActivity.this)
                              .execute(new LoginTask(usertext, passtext));
+                    mProgressDialog = new ProgressDialog(LoginActivity.this);
+                    mProgressDialog.setMessage(getResources().getString(R.string.progress_dialog_login));
+                    mProgressDialog.show();
                 }
             }
         });
@@ -118,6 +125,8 @@ public class LoginActivity extends BaseActivity
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(LoginTask task) {
+        mProgressDialog.dismiss();
+
         if (AppPrefs.getInstance(this).isLoggedIn()) {
             broadcastLogInSuccess(this);
             startActivity(MainActivity.getLaunchIntent(this));

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -1,4 +1,5 @@
 package org.dosomething.letsdothis.ui;
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -52,6 +53,9 @@ public class RegisterActivity extends BaseActivity
 
     // Google Analytics tracker
     private Tracker mTracker;
+
+    // Progress dialog while login is in progress
+    private ProgressDialog mProgressDialog;
 
     public static Intent getLaunchIntent(Context context, FbUser user)
     {
@@ -248,6 +252,9 @@ public class RegisterActivity extends BaseActivity
 
                     TaskQueue.loadQueueDefault(RegisterActivity.this).execute(
                             new RegisterTask(emailText, phoneText, passText, firstText));
+                    mProgressDialog = new ProgressDialog(RegisterActivity.this);
+                    mProgressDialog.setMessage(getResources().getString(R.string.progress_dialog_register));
+                    mProgressDialog.show();
 
                     // Track if user provided mobile # in registration
                     if (!phoneText.isEmpty()) {
@@ -280,6 +287,8 @@ public class RegisterActivity extends BaseActivity
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(RegisterTask task) {
+        mProgressDialog.dismiss();
+
         AppPrefs prefs = AppPrefs.getInstance(this);
         if (prefs.getCurrentUserId() != null && prefs.getAvatarPath() != null) {
             TaskQueue.loadQueueDefault(RegisterActivity.this).execute(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,8 @@
     <string name="pref_suggestion_link">Have your own ideas? Fill out this form and let us know.</string>
     <string name="pref_version_key">pref_version_key</string>
     <string name="pref_version_text">v%1$s</string>
+    <string name="progress_dialog_login">Signing in...</string>
+    <string name="progress_dialog_register">Creating account...</string>
     <string name="expired_already">Oof. This action has expired. Let’s freshen things up.</string>
     <string name="max_kudos">99+</string>
     <string name="log_in_with_facebook">Log in with Facebook</string>


### PR DESCRIPTION
#### What's this PR do?

Displays a ProgressDialog while a sign in or register call is in progress. This should help avoid bugs that could come along when the user tries to resubmit and sign in or register request while one is already going.

Closes #179 
