### PR TITLE
React update 0.19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.facebook.android:facebook-android-sdk:4.7.0'
-    compile 'com.facebook.react:react-native:0.17.0'
+    compile 'com.facebook.react:react-native:0.19.0'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {
         transitive = true;
     }

--- a/app/react/newsfeed-view.js
+++ b/app/react/newsfeed-view.js
@@ -82,7 +82,7 @@ var NewsFeedView = React.createClass({
   renderLoadingView: function() {
     return (
       <View style={styles.loadingContainer}>
-        <ProgressBarAndroid animating={this.state.animating} style={styles.loadingIndicator} size="small" />
+        <ProgressBarAndroid animating={this.state.animating} style={styles.loadingIndicator} styleAttr="Small" />
         <Text style={Theme.styles.textBody}>
           Loading news...
         </Text>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "## Development",
   "main": "index.js",
   "dependencies": {
-    "react-native": "^0.17.0"
+    "react-native": "^0.19.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
#### What's this PR do?

Upgrades the React Native version we're using from 0.17 to 0.19.

And fixes one crash that surfaced after the upgrade.

#### Relevant issue

This is one potential step towards fixing #157. There's a proguard fix in React Native 0.19, but this PR doesn't yet get around to fully fixing the release builds.