### PR TITLE
Changes news feed loading icon to Normal from Small

### DIFF
--- a/app/react/newsfeed-view.js
+++ b/app/react/newsfeed-view.js
@@ -82,7 +82,7 @@ var NewsFeedView = React.createClass({
   renderLoadingView: function() {
     return (
       <View style={styles.loadingContainer}>
-        <ProgressBarAndroid animating={this.state.animating} style={styles.loadingIndicator} styleAttr="Small" />
+        <ProgressBarAndroid animating={this.state.animating} style={styles.loadingIndicator} styleAttr="Normal" />
         <Text style={Theme.styles.textBody}>
           Loading news...
         </Text>


### PR DESCRIPTION
It's what it looked like before we started correctly using the `styleAttr`.

![screen shot 2016-02-19 at 5 41 08 pm](https://cloud.githubusercontent.com/assets/696595/13191189/fd01c5fc-d72f-11e5-888b-0c95224c8c53.png)
