### PR TITLE
Fixes campaign signups

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NorthstarAPI.java
@@ -166,11 +166,18 @@ public interface NorthstarAPI {
     ResponseRbData getRbData(@Header("Session") String sessionToken,
                              @Path("id") int campId) throws NetworkException;
 
+    /**
+     * Sign up the logged in user for a campaign.
+     *
+     * @param sessionToken Token for the currently logged in user
+     * @param requestCampaignSignup
+     * @return ResponseCampaignSignUp
+     * @throws NetworkException
+     */
     @Headers("Content-Type: application/json")
-    @POST("/user/campaigns/{id}/signup")
-    ResponseCampaignSignUp campaignSignUp(@Body RequestCampaignSignup requestCampaignSignup,
-                                          @Path("id") int id,
-                                          @Header("Session") String sessionToken) throws NetworkException;
+    @POST("/signups")
+    ResponseCampaignSignUp submitSignUp(@Header("Session") String sessionToken,
+                                        @Body RequestCampaignSignup requestCampaignSignup) throws NetworkException;
 
     @Headers("Content-Type: application/json")
     @GET("/users/_id/{id}/campaigns")

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/RequestCampaignSignup.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/RequestCampaignSignup.java
@@ -3,16 +3,9 @@ package org.dosomething.letsdothis.network.models;
  * Created by izzyoji :) on 6/26/15.
  */
 public class RequestCampaignSignup {
+    // Label for where this signup originated from
+    public final String source = "mobileapp_android";
 
-    public final String source = "letsdothis_android";
-    public Integer group;
-
-    public RequestCampaignSignup() {
-        group = null;
-    }
-
-    public RequestCampaignSignup(Integer groupId) {
-        group = groupId;
-    }
-
+    // Campaign ID to signup for
+    public int campaign_id;
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/RequestReportback.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/RequestReportback.java
@@ -9,5 +9,5 @@ public class RequestReportback
     public String file;
     public final String why_participated = "(why_participated not provided in reportback submissions from the Android app)";
     public String caption;
-    public final String source = "letsdothis_android";
+    public final String source = "mobileapp_android";
 }

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaignSignUp.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaignSignUp.java
@@ -1,18 +1,31 @@
 package org.dosomething.letsdothis.network.models;
+
 /**
+ * Data structure of the response to a signup submission.
+ *
  * Created by izzyoji :) on 6/26/15.
  */
-public class ResponseCampaignSignUp
-{
+public class ResponseCampaignSignUp {
     public Wrapper data;
 
-    public static int getSignUpId(ResponseCampaignSignUp response)
-    {
-        return response.data.signup_id;
+    public static int getSignUpId(ResponseCampaignSignUp response) {
+        return response.data.id;
     }
 
-    private class Wrapper
-    {
-        public int signup_id;
+    private class Wrapper {
+        int id;
+        CampaignRunWrapper campaign_run;
+        CampaignWrapper campaign;
+
+        private class CampaignRunWrapper {
+            String id;
+            boolean current;
+        }
+
+        private class CampaignWrapper {
+            String id;
+            String title;
+            String tagline;
+        }
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignSignUpTask.java
@@ -16,7 +16,6 @@ import co.touchlab.android.threading.tasks.utils.NetworkUtils;
 /**
  * Created by izzyoji :) on 6/26/15.
  */
-//todo should this be persisted
 public class CampaignSignUpTask extends Task {
     // Campaign ID the signup is for
     private int mCampaignId;
@@ -76,10 +75,12 @@ public class CampaignSignUpTask extends Task {
         CampaignActions actions = CampaignActions.queryForId(context, mCampaignId);
         if (actions == null || actions.signUpId <= 0) {
             String sessionToken = AppPrefs.getInstance(context).getSessionToken();
-            RequestCampaignSignup requestCampaignSignup = new RequestCampaignSignup();
+            RequestCampaignSignup signup= new RequestCampaignSignup();
+            signup.campaign_id = mCampaignId;
+
             ResponseCampaignSignUp response = NetworkHelper.getNorthstarAPIService()
-                                                           .campaignSignUp(requestCampaignSignup,
-                                                                           mCampaignId, sessionToken);
+                    .submitSignUp(sessionToken, signup);
+
             CampaignActions campaignActions = new CampaignActions();
             campaignActions.campaignId = mCampaignId;
             campaignActions.signUpId = ResponseCampaignSignUp.getSignUpId(response);

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/RegisterTask.java
@@ -12,7 +12,7 @@ import co.touchlab.android.threading.eventbus.EventBusExt;
  * Created by toidiu on 4/15/15.
  */
 public class RegisterTask extends BaseRegistrationTask {
-    private final String SOURCE = "letsdothis_android";
+    private final String SOURCE = "mobileapp_android";
 
     private final String mEmail;
     private final String mPhone;

--- a/app/src/main/java/org/dosomething/letsdothis/ui/LoginActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/LoginActivity.java
@@ -13,6 +13,7 @@ import com.google.android.gms.analytics.Tracker;
 
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
+import org.dosomething.letsdothis.tasks.GetProfileSignupsTask;
 import org.dosomething.letsdothis.tasks.LoginTask;
 import org.dosomething.letsdothis.tasks.UpdateUserTask;
 import org.dosomething.letsdothis.utils.AnalyticsUtils;
@@ -131,9 +132,13 @@ public class LoginActivity extends BaseActivity
             broadcastLogInSuccess(this);
             startActivity(MainActivity.getLaunchIntent(this));
 
+            TaskQueue taskQueue = TaskQueue.loadQueueDefault(getApplicationContext());
             if (task.mUserNeedsUpdate) {
-                TaskQueue.loadQueueDefault(LoginActivity.this).execute(new UpdateUserTask(task.mLoggedInUser));
+                taskQueue.execute(new UpdateUserTask(task.mLoggedInUser));
             }
+
+            // Get user's actions to upade the local cache
+            taskQueue.execute(new GetProfileSignupsTask());
         }
         else {
             Snackbar snackbar = Snackbar

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -20,6 +20,7 @@ import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.FbUser;
+import org.dosomething.letsdothis.tasks.GetProfileSignupsTask;
 import org.dosomething.letsdothis.tasks.RegisterTask;
 import org.dosomething.letsdothis.tasks.UploadAvatarTask;
 import org.dosomething.letsdothis.utils.AnalyticsUtils;
@@ -289,16 +290,18 @@ public class RegisterActivity extends BaseActivity
     public void onEventMainThread(RegisterTask task) {
         mProgressDialog.dismiss();
 
+        TaskQueue taskQueue = TaskQueue.loadQueueDefault(getApplicationContext());
         AppPrefs prefs = AppPrefs.getInstance(this);
         if (prefs.getCurrentUserId() != null && prefs.getAvatarPath() != null) {
-            TaskQueue.loadQueueDefault(RegisterActivity.this).execute(
-                    new UploadAvatarTask(prefs.getCurrentUserId(), prefs.getAvatarPath())
-            );
+           taskQueue.execute(new UploadAvatarTask(prefs.getCurrentUserId(), prefs.getAvatarPath()));
         }
 
         if (prefs.isLoggedIn()) {
             broadcastLogInSuccess(this);
             startActivity(MainActivity.getLaunchIntent(this));
+
+            // Get user's actions to upade the local cache
+            taskQueue.execute(new GetProfileSignupsTask());
         }
         else {
             String message = task.getErrorMessage() != null ? task.getErrorMessage() : getString(R.string.fail_register);

--- a/app/src/main/java/org/dosomething/letsdothis/ui/StartActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/StartActivity.java
@@ -1,8 +1,6 @@
 package org.dosomething.letsdothis.ui;
 import android.os.Bundle;
-import android.view.View;
 
-import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.utils.AppPrefs;
 
 /**

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -15,6 +15,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import com.google.android.gms.analytics.Tracker;
 
@@ -22,6 +23,7 @@ import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.Campaign;
+import org.dosomething.letsdothis.data.CampaignActions;
 import org.dosomething.letsdothis.network.models.ResponseProfileCampaign;
 import org.dosomething.letsdothis.network.models.ResponseProfileSignups;
 import org.dosomething.letsdothis.tasks.GetProfileSignupsTask;
@@ -36,6 +38,7 @@ import org.dosomething.letsdothis.ui.adapters.HubAdapter;
 import org.dosomething.letsdothis.utils.AnalyticsUtils;
 
 import java.io.File;
+import java.sql.SQLException;
 import java.util.ArrayList;
 
 import co.touchlab.android.threading.eventbus.EventBusExt;
@@ -304,6 +307,20 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
                 // Campaigns that the user has signed up for but has no reportback yet
                 else if (signups.data[i].campaign_run.current) {
                     currentSignups.add(signups.data[i].campaign);
+                }
+
+                // Update local cache of actions
+                try {
+                    CampaignActions actions = new CampaignActions();
+                    actions.campaignId = Integer.parseInt(signups.data[i].campaign.id);
+                    actions.signUpId = Integer.parseInt(signups.data[i].id);
+                    if (signups.data[i].reportback != null) {
+                        actions.reportBackId = Integer.parseInt(signups.data[i].reportback.id);
+                    }
+                    CampaignActions.save(getActivity(), actions);
+                }
+                catch (SQLException e) {
+                    Toast.makeText(getActivity(), R.string.error_hub_sync, Toast.LENGTH_SHORT).show();
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     </string>
     <string name="done">Done</string>
     <string name="error_avatar_upload">There was an error uploading your photo</string>
+    <string name="error_hub_sync">There was an error syncing your profile</string>
     <string name="error_interest_group_titles">There was an error getting campaign info</string>
     <string name="error_login_phone_email">Must not be empty</string>
     <string name="error_login_password">Must not be empty</string>


### PR DESCRIPTION
#### What's this PR do?

Fixes campaign signups to work with the updated API.

**Commits:**
- Fixes the campaign signup API call
  - also changes the source value for register, signup and reportback calls from letsdothis_android to mobileapp_android
- Updates local cache of a user's campaign actions when opening up the Hub
- Get user's campaign actions from server and cache to local after login or register

#### Relevant issues

Fixes #191 