### PR TITLE
Crashlytics fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,7 +124,7 @@ dependencies {
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'com.facebook.android:facebook-android-sdk:4.7.0'
     compile 'com.facebook.react:react-native:0.19.0'
-    compile('com.crashlytics.sdk.android:crashlytics:2.5.2@aar') {
+    compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true;
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -114,6 +114,9 @@
 
         <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
 
+        <!-- Crashlytics -->
+        <meta-data android:name="io.fabric.ApiKey" android:value="7e81fd514f3c96fe814c7225e180f175ecff3d54" />
+
         <!-- Parse-->
         <meta-data android:name="com.parse.push.notification_icon" android:resource="@drawable/push_icon"/>
         <service android:name="com.parse.PushService" />


### PR DESCRIPTION
Updates Crashlytics to 2.5.5 and adds api key to the manifest.

Definitely tried hiding the Crashlytics API key in our local secrets.properties file and loading it in through Gradle, but it wasn't working for some reason. It feels ok enough exposing this key. If it somehow does get abused, we can change and find a better way of handling it then