### PR TITLE
Displays an empty view in the Hub if user has no signups

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
@@ -302,8 +302,14 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             }
         }
 
-        // Adds signups to the list displayed to the Hub
-        mHubList.addAll(campaigns);
+        if (! mIsPublic && (campaigns == null || campaigns.isEmpty())) {
+            // Adds the empty view
+            mHubList.add(CURRENT_CAMPAIGNS_EMPTY_STUB);
+        }
+        else {
+            // Adds signups to the list displayed to the Hub
+            mHubList.addAll(campaigns);
+        }
 
         // And then add back any reportbacks, if any
         mHubList.addAll(reportbacks);
@@ -318,16 +324,18 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public void setCompletedActions(ArrayList<ResponseProfileSignups.Signup> actions) {
         // Remove items in the current "actions done" list and replace it with the new ones
         if (mHubList.indexOf(REPORTBACKS_LABEL_STUB) >= 0) {
-            for (int i = mHubList.size() - 1; i > mHubList.indexOf(REPORTBACKS_LABEL_STUB); i--) {
+            for (int i = mHubList.size() - 1; i >= mHubList.indexOf(REPORTBACKS_LABEL_STUB); i--) {
                 mHubList.remove(i);
             }
         }
-        // Add the "actions done" label
-        else {
-            mHubList.add(REPORTBACKS_LABEL_STUB);
-        }
 
-        mHubList.addAll(actions);
+        if (actions != null && ! actions.isEmpty()) {
+            // Add the "actions done" label
+            mHubList.add(REPORTBACKS_LABEL_STUB);
+
+            // Add the reportbacks
+            mHubList.addAll(actions);
+        }
         notifyDataSetChanged();
     }
 

--- a/app/src/main/res/layout/item_hub_current_empty.xml
+++ b/app/src/main/res/layout/item_hub_current_empty.xml
@@ -13,7 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/padding_medium"
         android:text="@string/hub_empty_text1"
-        android:textColor="@color/gray"
+        android:textColor="@color/dark_gray"
         android:textSize="@dimen/text_large"
         android:textStyle="bold"
         app:typeface="brandon_bold"/>
@@ -26,9 +26,9 @@
         android:layout_marginRight="@dimen/padding_medium"
         android:gravity="center_horizontal"
         android:text="@string/hub_empty_text2"
-        android:textColor="@color/black_70"
+        android:textColor="@android:color/black"
         android:textSize="@dimen/text_medium"
-        app:typeface="brandon_bold"/>
+        app:typeface="brandon_regular"/>
 
     <org.dosomething.letsdothis.ui.views.typeface.CustomButton
         android:id="@+id/actions"
@@ -37,6 +37,7 @@
         android:layout_marginBottom="@dimen/padding_large"
         android:text="@string/hub_empty_action_button"
         android:textAllCaps="true"
-        app:typeface="brandon_bold"/>
+        app:typeface="brandon_bold"
+        style="@style/SecondaryButton"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,9 +27,8 @@
     <string name="hub_current_label_public">Actions They\'re Doing Now</string>
     <string name="hub_empty_action_button">Take Me There</string>
     <string name="hub_empty_public">Hm, we aren\'t able to find any activity for this user.</string>
-    <string name="hub_empty_text1">No actions? No problem!</string>
-    <string name="hub_empty_text2">We release 12 new things to do every month, so check your Actions
-        tab for what\'s fresh.</string>
+    <string name="hub_empty_text1">You haven\'t started any actions yet.</string>
+    <string name="hub_empty_text2">And you totally should! Shit is happening in the world -- find out how to do something about it.</string>
     <string name="hub_done_label">Actions I\'ve Done</string>
     <string name="hub_done_label_public">Actions They\'ve Done</string>
     <string name="nav_news">News</string>


### PR DESCRIPTION
#### What's this PR do?

![screen shot 2016-02-25 at 2 56 15 pm](https://cloud.githubusercontent.com/assets/696595/13332500/4116d422-dbd0-11e5-89c1-5d482432d1bb.png)

- Displays the "empty view" Hub layout if the user has no current signups
- Ensures the "empty view" doesn't display when viewing public / other user profiles
- Doesn't show the "Actions I've Done" label if there are no reportbacks

#### Relevant issues

Fixes #202 