### PR TITLE
Hub crash fix

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -333,7 +333,9 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
                     completedActions.add(signups.data[i]);
                 }
                 // Campaigns that the user has signed up for but has no reportback yet
-                else if (signups.data[i].campaign_run.current) {
+                // Campaign must be current. All should have a run, but if not, let's just default
+                // to showing it in the list.
+                else if (signups.data[i].campaign_run == null || signups.data[i].campaign_run.current) {
                     currentSignups.add(signups.data[i].campaign);
                 }
 


### PR DESCRIPTION
Fixes crash in the Hub when a campaign doesn't return a campaign_run object.

Fixes #212 