### PR TITLE
Fixes issue where some campaigns didn't show approved reportback items

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -157,7 +157,7 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     @Override
     public void onBindViewHolder(final RecyclerView.ViewHolder holder, final int position)
     {
-        if (position == dataSet.size() - 3) {
+        if (position >= dataSet.size() - 3) {
             detailsAdapterClickListener.onScrolledToBottom();
         }
 


### PR DESCRIPTION
Closes #218 

Turns out we already were querying for `approved` and `promoted` status. We currently query for promoted first, and then approved. There was a bug though were particularly short lists wouldn't make the second call for approved ones. This should fix that.