### PR TITLE
Prevents signup for closed campaigns

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseReportBackList.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseReportBackList.java
@@ -12,13 +12,17 @@ public class ResponseReportBackList
 {
 
     public ReportBack data[];
-    public Pagination pagination;
+    public PaginationWrapper meta;
 
     // If there's an error, the response will instead include this object
     public Error error;
 
     public static List<ReportBack> getReportBacks(ResponseReportBackList response) {
         return new ArrayList<>(Arrays.asList(response.data));
+    }
+
+    public static class PaginationWrapper {
+        public Pagination pagination;
     }
 
     public static class Pagination {

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseReportBackListTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseReportBackListTask.java
@@ -51,7 +51,9 @@ public abstract class BaseReportBackListTask extends BaseNetworkErrorHandlerTask
             error = response.error.message;
         }
         else {
-            totalPages = response.pagination.total_pages;
+            if (response.meta != null && response.meta.pagination != null) {
+                totalPages = response.meta.pagination.total_pages;
+            }
             reportBacks = ResponseReportBackList.getReportBacks(response);
         }
     }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -417,7 +417,7 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
         totalPages = task.totalPages;
         currentPage = task.page;
         List<ReportBack> reportBacks = task.reportBacks;
-        if (reportBacks != null) {
+        if (reportBacks != null && ! reportBacks.isEmpty()) {
             adapter.addAll(reportBacks);
         }
         else if (currentRbQueryStatus == BaseReportBackListTask.STATUS_PROMOTED) {

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -212,9 +212,16 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                 }
             }
 
+
             // Action button
-            if (!mUserIsSignedUp) {
+            campaignViewHolder.actionButton.setVisibility(View.VISIBLE);
+            if (! mUserIsSignedUp) {
                 campaignViewHolder.actionButton.setText(res.getString(R.string.stop_being_bored));
+
+                // Hide the action button if the campaign is closed
+                if (campaign.status != null && campaign.status.equals("closed")) {
+                    campaignViewHolder.actionButton.setVisibility(View.GONE);
+                }
             }
             else if (campaign.showShare == Campaign.UploadShare.SHARE) {
                 campaignViewHolder.actionButton.setText(R.string.cta_photo_in_hub);
@@ -224,6 +231,10 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
             }
             else if (campaign.showShare == Campaign.UploadShare.SHOW_OFF) {
                 campaignViewHolder.actionButton.setText(res.getString(R.string.show_off));
+
+                if (campaign.status != null && campaign.status.equals("closed")) {
+                    campaignViewHolder.actionButton.setVisibility(View.GONE);
+                }
             }
 
             campaignViewHolder.actionButton.setOnClickListener(new View.OnClickListener() {
@@ -235,10 +246,10 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
 
                         detailsAdapterClickListener.onSignupClicked(campaign.id);
                     }
-                    else if(campaign.showShare == Campaign.UploadShare.SHARE) {
+                    else if (campaign.showShare == Campaign.UploadShare.SHARE) {
                         detailsAdapterClickListener.shareClicked(campaign);
                     }
-                    else if(campaign.showShare == Campaign.UploadShare.SHOW_OFF) {
+                    else if (campaign.showShare == Campaign.UploadShare.SHOW_OFF) {
                         detailsAdapterClickListener.proveClicked();
                     }
                 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -349,18 +349,20 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
                     currentSignups.add(signups.data[i].campaign);
                 }
 
-                // Update local cache of actions
-                try {
-                    CampaignActions actions = new CampaignActions();
-                    actions.campaignId = Integer.parseInt(signups.data[i].campaign.id);
-                    actions.signUpId = Integer.parseInt(signups.data[i].id);
-                    if (signups.data[i].reportback != null) {
-                        actions.reportBackId = Integer.parseInt(signups.data[i].reportback.id);
+                // Update local cache of actions. Skip if displaying a public user profile.
+                // If an EXTRA_ID string arg exists, then this is for a public profile.
+                if (getArguments().getString(EXTRA_ID, null) == null) {
+                    try {
+                        CampaignActions actions = new CampaignActions();
+                        actions.campaignId = Integer.parseInt(signups.data[i].campaign.id);
+                        actions.signUpId = Integer.parseInt(signups.data[i].id);
+                        if (signups.data[i].reportback != null) {
+                            actions.reportBackId = Integer.parseInt(signups.data[i].reportback.id);
+                        }
+                        CampaignActions.save(getActivity(), actions);
+                    } catch (SQLException e) {
+                        Toast.makeText(getActivity(), R.string.error_hub_sync, Toast.LENGTH_SHORT).show();
                     }
-                    CampaignActions.save(getActivity(), actions);
-                }
-                catch (SQLException e) {
-                    Toast.makeText(getActivity(), R.string.error_hub_sync, Toast.LENGTH_SHORT).show();
                 }
             }
         }


### PR DESCRIPTION
#### What's this PR do?

If a user somehow gets to a campaign screen for a closed campaign, we hide the Sign Up / Prove It button from the view. They could potentially get there through other user profiles or the news feed or... I don't know, maybe there are other ways.

![screen shot 2016-03-02 at 4 03 00 pm](https://cloud.githubusercontent.com/assets/696595/13475395/995f82e0-e090-11e5-8bc4-984afeda9be6.png)

Plus a couple unrelated fixes because why not: 
- Fixes the response data structure to a `GET reportback-items` call. The `pagination` object is now wrapped inside a `meta` object.
- Fixes bug where a campaign state would incorrectly be shown to a user as if they signed into it. This would occur after the user would visit the profile of another user who had signed up for that campaign.

#### Relevant issues

Closes #219

cc: @aaronschachter 