### PR TITLE
Prevents a reportback caption with emojis or special symbols

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackUploadActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackUploadActivity.java
@@ -102,16 +102,17 @@ public class ReportBackUploadActivity extends AppCompatActivity
                 RequestReportback req = new RequestReportback();
                 req.caption = caption.getText().toString();
                 if (req.caption.equals("")) {
-                    Toast.makeText(ReportBackUploadActivity.this, "Please enter a valid caption.",
-                                   Toast.LENGTH_SHORT).show();
+                    caption.setError(getString(R.string.error_reportback_invalid_caption));
+                    return;
+                } else if (hasEmoji(req.caption)) {
+                    caption.setError(getString(R.string.error_reportback_emoji_caption));
+                    return;
                 }
 
                 try {
                     Integer.parseInt(number.getText().toString());
-                }
-                catch (NumberFormatException e) {
-                    Toast.makeText(ReportBackUploadActivity.this, "Enter a valid number.",
-                                   Toast.LENGTH_SHORT).show();
+                } catch (NumberFormatException e) {
+                    number.setError(getString(R.string.error_reportback_invalid_quantity));
                     return;
                 }
 
@@ -142,5 +143,25 @@ public class ReportBackUploadActivity extends AppCompatActivity
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    /**
+     * Checks if a string has any emoji characters.
+     *
+     * @param text String to check
+     * @return boolean. True if an emoji is found. Otherwise, false.
+     */
+    private boolean hasEmoji(String text) {
+        for (int i = 0; text != null && i < text.length(); i++) {
+            int charType = Character.getType(text.charAt(i));
+
+            // This will also reject some non-emoji characters. But I think they're still in a range
+            // that don't really make sense for us to allow in a reportback caption.
+            if (charType == Character.SURROGATE || charType == Character.OTHER_SYMBOL) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,9 @@
     <string name="error_registration_email">We need a valid email</string>
     <string name="error_registration_first_name">We need your first name</string>
     <string name="error_registration_password">Your password must be 6+ characters</string>
+    <string name="error_reportback_emoji_caption">You cannot use emojis or symbols in your caption :(</string>
+    <string name="error_reportback_invalid_caption">Please enter a valid caption</string>
+    <string name="error_reportback_invalid_quantity">Please enter a valid number</string>
     <string name="error_signup">There was an error signing up for the campaign</string>
     <string name="tell_us">Let\'s get to know each other.</string>
     <string name="footer_register">Have a DoSomething.org account? Sign in</string>


### PR DESCRIPTION
#### What's this PR do?

Prevents a reportback caption with emojis or special symbols.

This also sets the error message on the relevant EditText boxes instead of showing it as a Toast message. This matches how we do error message handling on the registration and login forms.

#### Relevant issues?

Closes #180 