### PR TITLE
Fixes registration error handling

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
@@ -81,6 +81,7 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
         if (throwable instanceof RetrofitError) {
             RetrofitError retrofitError = (RetrofitError) throwable;
             RegistrationError regError = (RegistrationError) retrofitError.getBodyAs(RegistrationError.class);
+            mErrorMessage = regError.message;
             if (regError.errors != null) {
                 if (regError.errors.email.length > 0) {
                     mErrorMessage = regError.errors.email[0];
@@ -88,9 +89,6 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
                 else if (regError.errors.password.length > 0) {
                     mErrorMessage = regError.errors.password[0];
                 }
-            }
-            else {
-                mErrorMessage = regError.message;
             }
 
             return true;

--- a/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/BaseRegistrationTask.java
@@ -81,7 +81,17 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
         if (throwable instanceof RetrofitError) {
             RetrofitError retrofitError = (RetrofitError) throwable;
             RegistrationError regError = (RegistrationError) retrofitError.getBodyAs(RegistrationError.class);
-            mErrorMessage = regError.error.message;
+            if (regError.errors != null) {
+                if (regError.errors.email.length > 0) {
+                    mErrorMessage = regError.errors.email[0];
+                }
+                else if (regError.errors.password.length > 0) {
+                    mErrorMessage = regError.errors.password[0];
+                }
+            }
+            else {
+                mErrorMessage = regError.message;
+            }
 
             return true;
         }
@@ -103,12 +113,14 @@ public abstract class BaseRegistrationTask extends BaseNetworkErrorHandlerTask
      * Data structure of error returned from a registration attempt.
      */
     class RegistrationError {
-        class RegistrationErrorBody {
-            public int code;
-            public String message;
-        }
+        public int code;
+        public String message;
+        public RegistrationErrorBody errors;
 
-        public RegistrationErrorBody error;
+        class RegistrationErrorBody {
+            public String email[];
+            public String password[];
+        }
     }
 
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/RegisterActivity.java
@@ -157,7 +157,7 @@ public class RegisterActivity extends BaseActivity
         email.setBackgroundResource(R.drawable.bg_white_rounded_rect_filled);
         password.setBackgroundResource(R.drawable.bg_white_rounded_rect_filled);
 
-        String inputFName = firstName.getText().toString();
+        String inputFName = firstName.getText().toString().trim();
         if (inputFName.isEmpty()) {
             String fnameError = getResources().getString(R.string.error_registration_first_name);
             firstName.setError(fnameError);
@@ -165,7 +165,7 @@ public class RegisterActivity extends BaseActivity
             isValid = false;
         }
 
-        String inputEmail = email.getText().toString();
+        String inputEmail = email.getText().toString().trim();
         if (inputEmail.isEmpty() || !Patterns.EMAIL_ADDRESS.matcher(inputEmail).matches()) {
             String emailError = getResources().getString(R.string.error_registration_email);
             email.setError(emailError);


### PR DESCRIPTION
#### What's this PR do?

- The API response for registration errors has changed, so this update is to match those changes.
- Spaces after an email would also incorrectly trigger it as an invalid email. The fix added here is just to do a trim before running validation. We already have it do a trim before submitting the registration request.

#### Relevant issues

Closes #227