### PR TITLE
Cause screen fixes

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/PhoenixAPI.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/PhoenixAPI.java
@@ -44,7 +44,9 @@ public interface PhoenixAPI {
 
     @Headers("Content-Type: application/json")
     @GET("/campaigns.json")
-    ResponseCampaignList campaignListByCause(@Query("term_ids") int causeId) throws NetworkException;
+    ResponseCampaignList campaignListByCause(
+            @Query("term_ids") int causeId,
+            @Query("page") int page) throws NetworkException;
 
     @Headers("Content-Type: application/json")
     @GET("/campaigns.json?mobile_app=1")

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaignList.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaignList.java
@@ -11,7 +11,31 @@ import java.util.List;
  */
 public class ResponseCampaignList {
 
+    private PaginationWrapper pagination;
     private ResponseCampaign[] data;
+
+    private class PaginationWrapper {
+        int current_page;
+        int total_pages;
+    }
+
+    /**
+     * Returns the current page number of the response.
+     *
+     * @return int
+     */
+    public int getCurrentPage() {
+        return pagination != null ? pagination.current_page : 0;
+    }
+
+    /**
+     * Returns the total number of pages available.
+     *
+     * @return int
+     */
+    public int getTotalPages() {
+        return pagination != null ? pagination.total_pages : 0;
+    }
 
     /**
      * Transform the data array into a usable list of Campaigns.

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CauseActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CauseActivity.java
@@ -132,8 +132,10 @@ public class CauseActivity extends BaseActivity {
         mProgressBar.setVisibility(View.GONE);
 
         ResponseCampaignList response = task.getResults();
-        mAdapter.setCampaigns(response.getCampaigns(true));
-        mAdapter.notifyDataSetChanged();
+        if (response != null) {
+            mAdapter.setCampaigns(response.getCampaigns(true));
+            mAdapter.notifyDataSetChanged();
+        }
     }
 
     /**

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CauseActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CauseActivity.java
@@ -131,9 +131,9 @@ public class CauseActivity extends BaseActivity {
     public void onEventMainThread(GetCampaignsByCauseTask task) {
         mProgressBar.setVisibility(View.GONE);
 
-        ResponseCampaignList response = task.getResults();
-        if (response != null) {
-            mAdapter.setCampaigns(response.getCampaigns(true));
+        ArrayList<Campaign> campaigns = task.getResults();
+        if (campaigns != null) {
+            mAdapter.setCampaigns(campaigns);
             mAdapter.notifyDataSetChanged();
         }
     }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CauseActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CauseActivity.java
@@ -179,9 +179,9 @@ public class CauseActivity extends BaseActivity {
                 int red = (color >> 16) & 0xff;
                 int green = (color >> 8) & 0xff;
                 int blue = color & 0xff;
-                int alpha = 0x77;
+                int alpha = 0xff;
 
-                holder.mBackground.setColorFilter(Color.argb(alpha, red, green, blue));
+                holder.mBackground.setBackgroundColor(Color.argb(alpha, red, green, blue));
                 holder.mTitle.setText(mCauseName.toUpperCase());
                 holder.mDescription.setText(Causes.getDescriptionRes(mCauseName));
 

--- a/app/src/main/res/layout/item_cause_header.xml
+++ b/app/src/main/res/layout/item_cause_header.xml
@@ -9,15 +9,11 @@
         android:layout_width="match_parent"
         android:layout_height="150dp">
 
-        <!-- @todo The current src pattern is a temporary placeholder -->
         <ImageView
             android:id="@+id/title_bg"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="fitXY"
-            android:src="@drawable/bg_onboarding_bitmap"
-            android:tint="@color/cause_default"
-            android:tintMode="multiply"/>
+            android:background="@color/cause_default"/>
 
         <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
             android:id="@+id/title"


### PR DESCRIPTION
#### What's this PR do?

- Fixes a crash on the Cause screen when there's no network connection
- Fixes an issue where only the first 25 campaigns under a cause would be loaded into the list
- Changes the background color of the cause header to a solid color instead of using a pattern

#### Relevant issues

Closes #231 
Closes #233