### PR TITLE
Adds user stats to the profile header

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
@@ -41,6 +41,10 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private boolean mIsPublic = false;
     private User mUser;
 
+    // Displayed action counts
+    private int mActionsCount = 0;
+    private int mPhotosCount = 0;
+
     public HubAdapter(Context context, HubAdapterClickListener hubAdapterClickListener, boolean isPublic) {
         super();
 
@@ -128,9 +132,11 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
                         .into(profileViewHolder.userImage);
             }
 
-            profileViewHolder.name.setText(formatUserDisplayName(user.first_name, user.last_initial));
             profileViewHolder.userCountry.setText(formatUserLocation(user.country));
             profileViewHolder.userCountry.setAlpha(0.26f);
+
+            profileViewHolder.actionsCount.setText(String.valueOf(mActionsCount));
+            profileViewHolder.photosCount.setText(String.valueOf(mPhotosCount));
         }
         else if (getItemViewType(position) == VIEW_TYPE_CURRENT_SIGNUPS) {
             ResponseProfileCampaign campaign = (ResponseProfileCampaign) mHubList.get(position);
@@ -305,10 +311,12 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         if (! mIsPublic && (campaigns == null || campaigns.isEmpty())) {
             // Adds the empty view
             mHubList.add(CURRENT_CAMPAIGNS_EMPTY_STUB);
+            mActionsCount = 0;
         }
         else {
             // Adds signups to the list displayed to the Hub
             mHubList.addAll(campaigns);
+            mActionsCount = campaigns.size();
         }
 
         // And then add back any reportbacks, if any
@@ -336,7 +344,13 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
             // Add the reportbacks
             mHubList.addAll(actions);
+
+            mPhotosCount = actions.size();
         }
+        else {
+            mPhotosCount = 0;
+        }
+
         notifyDataSetChanged();
     }
 
@@ -347,14 +361,16 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     public static class ProfileViewHolder extends RecyclerView.ViewHolder {
         protected ImageView userImage;
-        protected TextView  name;
         protected TextView  userCountry;
+        protected TextView  actionsCount;
+        protected TextView  photosCount;
 
         public ProfileViewHolder(View itemView) {
             super(itemView);
             this.userImage = (ImageView) itemView.findViewById(R.id.user_image);
-            this.name = (TextView) itemView.findViewById(R.id.name);
             this.userCountry = (TextView) itemView.findViewById(R.id.user_country);
+            this.actionsCount = (TextView) itemView.findViewById(R.id.actions_count);
+            this.photosCount = (TextView) itemView.findViewById(R.id.photos_count);
         }
     }
 

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -330,7 +330,13 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
 
         User user = task.getResult();
         if (user != null) {
-            mTitleListener.setTitle(user.first_name);
+            String first = user.first_name != null ? user.first_name : "";
+            String last = "";
+            if (user.last_initial != null && ! user.last_initial.isEmpty()) {
+                last = user.last_initial + ".";
+            }
+
+            mTitleListener.setTitle(String.format("%s %s", first, last).trim());
         }
 
         mAdapter.setUser(user);

--- a/app/src/main/res/layout/fragment_register_login.xml
+++ b/app/src/main/res/layout/fragment_register_login.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tool:background="#faaf00">
+    tool:background="@color/theme_primary">
 
     <ImageView
         android:layout_width="@dimen/login_intro_w"
@@ -29,6 +29,7 @@
             android:layout_marginBottom="@dimen/padding_xlarge"
             android:layout_marginLeft="40dp"
             android:layout_marginRight="40dp"
+            android:textSize="@dimen/text_medium"
             android:text="@string/desc_login_reg"/>
 
         <org.dosomething.letsdothis.ui.views.typeface.CustomButton

--- a/app/src/main/res/layout/item_hub_profile.xml
+++ b/app/src/main/res/layout/item_hub_profile.xml
@@ -4,51 +4,93 @@
     xmlns:tool="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/hub_profile_header"
+    android:background="@drawable/bg_profile">
 
-    <LinearLayout
+    <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+        android:id="@+id/user_country"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:padding="10dp"
+        android:textAllCaps="true"
+        android:textColor="@color/white"
+        android:textSize="@dimen/text_medium"
+        app:typeface="brandon_bold"
+        tool:text="New Zealand"/>
+
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="@dimen/hub_profile_header"
-        android:background="@drawable/bg_profile"
-        android:gravity="center"
-        android:orientation="vertical">
+        android:layout_height="wrap_content"
+        android:layout_above="@id/user_country">
 
         <org.dosomething.letsdothis.ui.views.CircleImageView
             android:id="@+id/user_image"
             android:layout_width="@dimen/hub_avatar_height"
             android:layout_height="@dimen/hub_avatar_height"
+            android:layout_centerInParent="true"
             android:src="@drawable/default_profile_photo"
             app:border_color="@color/white"
             app:border_width="@dimen/padding_tiny"
             app:draw_border="true"
             />
 
-        <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
-            android:id="@+id/name"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingLeft="@dimen/padding_small"
-            android:paddingRight="@dimen/padding_small"
-            android:paddingTop="@dimen/padding_small"
-            android:textAllCaps="true"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_48"
-            app:typeface="brandon_bold"
-            tool:text="Person P."/>
+            android:layout_toLeftOf="@id/user_image"
+            android:layout_centerVertical="true"
+            android:gravity="center"
+            android:orientation="vertical">
 
-        <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
-            android:id="@+id/user_country"
-            android:layout_width="wrap_content"
+            <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+                android:id="@+id/actions_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_xxxlarge"
+                app:typeface="brandon_bold"
+                tool:text="0"/>
+
+            <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/hub_actions_label"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_medium"
+                app:typeface="brandon_regular"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/padding_small"
-            android:paddingLeft="@dimen/padding_small"
-            android:paddingRight="@dimen/padding_small"
-            android:textAllCaps="true"
-            android:textColor="@color/white"
-            app:typeface="brandon_bold"
-            tool:text="New Zealand"/>
+            android:layout_toRightOf="@id/user_image"
+            android:layout_centerVertical="true"
+            android:gravity="center"
+            android:orientation="vertical">
 
-    </LinearLayout>
+            <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+                android:id="@+id/photos_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_xxxlarge"
+                app:typeface="brandon_bold"
+                tool:text="0"/>
+
+            <org.dosomething.letsdothis.ui.views.typeface.CustomTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/hub_photos_label"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_medium"
+                app:typeface="brandon_regular"/>
+
+        </LinearLayout>
+
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -51,8 +51,8 @@
     <dimen name="text_42">21sp</dimen>
     <dimen name="text_36">@dimen/text_large</dimen>
     <dimen name="text_48">@dimen/text_xlarge</dimen>
-    <dimen name="hub_profile_header">169dp</dimen>
-    <dimen name="hub_avatar_height">75dp</dimen>
+    <dimen name="hub_profile_header">144dp</dimen>
+    <dimen name="hub_avatar_height">78dp</dimen>
     <dimen name="report_back_expanded">375dp</dimen>
     <dimen name="notification_image">60dp</dimen>
     <dimen name="avatar">100dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="cause_violence_desc">Learn how to fight back without fighting back.</string>
     <string name="cta_photo_in_hub">See Your Photo</string>
     <string name="hub">Me</string>
+    <string name="hub_actions_label">Actions</string>
     <string name="hub_current_label">Actions I\'m Doing Now</string>
     <string name="hub_current_label_public">Actions They\'re Doing Now</string>
     <string name="hub_empty_action_button">Take Me There</string>
@@ -31,6 +32,7 @@
     <string name="hub_empty_text2">And you totally should! Shit is happening in the world -- find out how to do something about it.</string>
     <string name="hub_done_label">Actions I\'ve Done</string>
     <string name="hub_done_label_public">Actions They\'ve Done</string>
+    <string name="hub_photos_label">Photos</string>
     <string name="nav_news">News</string>
     <string name="notifications">Notifications</string>
     <string name="staff_pick">Staff pick</string>
@@ -51,7 +53,7 @@
     <string name="share_photo">Share Your Photo</string>
     <string name="show_off">Prove It</string>
     <string name="friends">Friends</string>
-    <string name="desc_login_reg">Let’s make this official. Create an account to find news around
+    <string name="desc_login_reg">Let’s make this official.\nCreate an account to find news around
         your top causes and ways to take action.
     </string>
     <string name="settings">Settings</string>


### PR DESCRIPTION
#### What's this PR do?

The number of signups and reportbacks are now displayed in the top section of the profile.

Other changes:
- the user's name is taken out of the top section and moved into the toolbar
- totally unrelated to the Hub: new line added to the login/reg onboarding screen

![screen shot 2016-03-04 at 5 13 41 pm](https://cloud.githubusercontent.com/assets/696595/13542025/18d98874-e22e-11e5-8143-3f118c779890.png)

#### Relevant issues

Closes #174 