### PR TITLE
Sanitizes first name when displayed

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/CampaignDetailsAdapter.java
@@ -15,7 +15,7 @@ import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.data.Campaign;
 import org.dosomething.letsdothis.data.Kudos;
 import org.dosomething.letsdothis.data.ReportBack;
-import org.dosomething.letsdothis.ui.views.SlantedBackgroundDrawable;
+import org.dosomething.letsdothis.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,12 +30,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     public static final int VIEW_TYPE_CAMPAIGN        = 0;
     public static final int VIEW_TYPE_CAMPAIGN_FOOTER = 1;
     public static final int VIEW_TYPE_REPORT_BACK     = 2;
-
-    private final int webOrange;
-    private final int shadowColor;
-    private final int slantHeight;
-    private final int widthOvershoot;
-    private final int heightShadowOvershoot;
 
     //~=~=~=~=~=~=~=~=~=~=~=~=Fields
     private ArrayList<Object> dataSet = new ArrayList<>();
@@ -53,11 +47,6 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                                   Resources resources, boolean isSignedUp) {
         super();
         this.detailsAdapterClickListener = detailsAdapterClickListener;
-        webOrange = resources.getColor(R.color.web_orange);
-        shadowColor = resources.getColor(R.color.black_10);
-        slantHeight = resources.getDimensionPixelSize(R.dimen.height_xtiny);
-        widthOvershoot = resources.getDimensionPixelSize(R.dimen.space_50);
-        heightShadowOvershoot = resources.getDimensionPixelSize(R.dimen.padding_tiny);
         mUserIsSignedUp = isSignedUp;
         mSignupInProgress = false;
     }
@@ -242,11 +231,9 @@ public class CampaignDetailsAdapter extends RecyclerView.Adapter<RecyclerView.Vi
                     load(reportBack.getImagePath()).into(reportBackViewHolder.imageView);
 
             // User name
-            String reportbackName = reportBack.user.first_name;
-            if (reportBack.user.last_name != null && !reportBack.user.last_name.isEmpty()) {
-                reportbackName += " " + reportBack.user.last_name.charAt(0) + ".";
-            }
-            reportBackViewHolder.name.setText(reportbackName);
+            String name = ViewUtils.formatUserDisplayName(context, reportBack.user.first_name,
+                    reportBack.user.last_initial);
+            reportBackViewHolder.name.setText(name);
 
             // User country location
             if (reportBack.user.country != null && !reportBack.user.country.isEmpty()) {

--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
@@ -15,6 +15,7 @@ import org.dosomething.letsdothis.data.ReportBack;
 import org.dosomething.letsdothis.data.User;
 import org.dosomething.letsdothis.network.models.ResponseProfileCampaign;
 import org.dosomething.letsdothis.network.models.ResponseProfileSignups;
+import org.dosomething.letsdothis.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -159,7 +160,8 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
             // Use previously received User info
             if (mUser != null) {
-                rbViewHolder.name.setText(formatUserDisplayName(mUser.first_name, mUser.last_initial));
+                String name = ViewUtils.formatUserDisplayName(context, mUser.first_name, mUser.last_initial);
+                rbViewHolder.name.setText(name);
                 rbViewHolder.location.setText(formatUserLocation(mUser.country));
 
                 if (mUser.avatarPath != null) {
@@ -250,22 +252,6 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         }
 
         return "";
-    }
-
-    /**
-     * Helper function to format the displayed username.
-     *
-     * @param first User first name
-     * @param lastInitial User last initial, if any
-     * @return String
-     */
-    private String formatUserDisplayName(String first, String lastInitial) {
-        String last = "";
-        if (lastInitial != null && ! lastInitial.isEmpty()) {
-            last = lastInitial + ".";
-        }
-
-        return String.format("%s %s", first, last).trim();
     }
 
     /**

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -36,6 +36,7 @@ import org.dosomething.letsdothis.ui.PhotoCropActivity;
 import org.dosomething.letsdothis.ui.ReportBackUploadActivity;
 import org.dosomething.letsdothis.ui.adapters.HubAdapter;
 import org.dosomething.letsdothis.utils.AnalyticsUtils;
+import org.dosomething.letsdothis.utils.ViewUtils;
 
 import java.io.File;
 import java.sql.SQLException;
@@ -330,13 +331,8 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
 
         User user = task.getResult();
         if (user != null) {
-            String first = user.first_name != null ? user.first_name : "";
-            String last = "";
-            if (user.last_initial != null && ! user.last_initial.isEmpty()) {
-                last = user.last_initial + ".";
-            }
-
-            mTitleListener.setTitle(String.format("%s %s", first, last).trim());
+            String name = ViewUtils.formatUserDisplayName(getActivity(), user.first_name, user.last_initial);
+            mTitleListener.setTitle(name);
         }
 
         mAdapter.setUser(user);

--- a/app/src/main/java/org/dosomething/letsdothis/utils/ViewUtils.java
+++ b/app/src/main/java/org/dosomething/letsdothis/utils/ViewUtils.java
@@ -1,7 +1,10 @@
 package org.dosomething.letsdothis.utils;
 import android.content.Context;
 import android.content.res.Resources;
+import android.util.Patterns;
 import android.util.TypedValue;
+
+import org.dosomething.letsdothis.R;
 
 import java.io.File;
 
@@ -19,5 +22,28 @@ public class ViewUtils
     {
         return TypedValue
                 .applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, r.getDisplayMetrics());
+    }
+
+    /**
+     * Helper function to format the displayed username.
+     *
+     * @param context Context
+     * @param firstName User first name
+     * @param lastInitial User last initial, if any
+     * @return String
+     */
+    public static String formatUserDisplayName(Context context, String firstName, String lastInitial) {
+        // Sanitizing the first name because of rare cases where user's email was in that field
+        String first = firstName != null ? firstName : "";
+        if (Patterns.EMAIL_ADDRESS.matcher(first).matches()) {
+            first = context.getResources().getString(R.string.user_default_fname);
+        }
+
+        String last = "";
+        if (lastInitial != null && ! lastInitial.isEmpty()) {
+            last = lastInitial + ".";
+        }
+
+        return String.format("%s %s", first, last).trim();
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,5 +170,6 @@
     <string name="reportback_success">Reportback uploaded</string>
     <string name="drawer_desc_open">Drawer Open</string>
     <string name="drawer_desc_closed">Drawer Closed</string>
+    <string name="user_default_fname">Doer</string>
 
 </resources>


### PR DESCRIPTION
#### What's this PR do?

Changes first name to 'Doer' if the `first_name` field is an email.

It's been seen to happen in a couple rare cases so we're doing this to prevent private information from being shown. Logic to do this now is also moved to a static function in ViewUtils.

And unrelated, but also removed unused references that used to be needed for an old design.

#### Relevant issues

https://github.com/DoSomething/LetsDoThis-iOS/pull/933
