### PR TITLE
EditText polish

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackUploadActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/ReportBackUploadActivity.java
@@ -91,6 +91,9 @@ public class ReportBackUploadActivity extends AppCompatActivity
         Picasso.with(this).load(new File(croppedImage)).into(imageHero);
 
         final EditText caption = (EditText) findViewById(R.id.caption);
+        caption.setHorizontallyScrolling(false);
+        caption.setLines(2);
+
         final EditText number = (EditText) findViewById(R.id.number);
         number.setHint(getIntent().getStringExtra(EXTRA_COPY));
 

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -101,14 +101,18 @@
                 android:layout_marginLeft="@dimen/padding_small"
                 android:layout_marginRight="@dimen/padding_small"
                 android:layout_marginTop="@dimen/padding_small"
-                android:hint="@string/email"/>
+                android:hint="@string/email"
+                android:imeOptions="actionNext"
+                android:inputType="textEmailAddress"/>
 
             <org.dosomething.letsdothis.ui.views.typeface.CustomEditText
                 android:id="@+id/phone"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/padding_small"
-                android:hint="@string/phone"/>
+                android:hint="@string/phone"
+                android:imeOptions="actionNext"
+                android:inputType="phone"/>
 
             <org.dosomething.letsdothis.ui.views.typeface.CustomEditText
                 android:id="@+id/password"
@@ -117,7 +121,7 @@
                 android:layout_marginLeft="@dimen/padding_small"
                 android:layout_marginRight="@dimen/padding_small"
                 android:hint="@string/password_hint"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionDone"
                 android:inputType="textPassword"/>
 
             <org.dosomething.letsdothis.ui.views.typeface.CustomButton

--- a/app/src/main/res/layout/activity_report_back_upload.xml
+++ b/app/src/main/res/layout/activity_report_back_upload.xml
@@ -59,8 +59,8 @@
             android:focusableInTouchMode="true"
             android:gravity="top|left"
             android:hint="@string/report_back_caption"
-            android:inputType="textCapSentences|textMultiLine"
-            android:lines="2"
+            android:imeOptions="actionNext"
+            android:inputType="textCapSentences|textImeMultiLine"
             android:maxLength="60"/>
 
         <org.dosomething.letsdothis.ui.views.typeface.CustomEditText

--- a/app/src/main/res/layout/activity_signin.xml
+++ b/app/src/main/res/layout/activity_signin.xml
@@ -46,7 +46,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/padding_small"
-                android:hint="@string/phone_email">
+                android:hint="@string/phone_email"
+                android:imeOptions="actionNext">
                 <requestFocus/>
             </org.dosomething.letsdothis.ui.views.typeface.CustomEditText>
 
@@ -56,6 +57,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/padding_small"
                 android:hint="@string/password"
+                android:imeOptions="actionDone"
                 android:inputType="textPassword"/>
 
             <org.dosomething.letsdothis.ui.views.typeface.CustomButton


### PR DESCRIPTION
Adds ime options to input fields on the registration, login and reportback forms in the app. Also sets the `inputType` where appropriate. Adding these makes it easier for the user to fill out forms.

The work done in ReportBackUploadActivity.java was needed (as opposed to being able to do it strictly through XML) in order to create a multiline EditText field that also had the imeOption "actionNext" set.

Closes #245 