### PR TITLE
Fixes duplicate user stat views in the Hub

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
@@ -262,7 +262,7 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public void setUser(User user) {
         mUser = user;
 
-        if (! mHubList.isEmpty() && mHubList.get(0) instanceof User) {
+        if (! mHubList.isEmpty() && (mHubList.get(0) == null || mHubList.get(0) instanceof User)) {
             mHubList.set(0, user);
         }
         else {


### PR DESCRIPTION
This fixes this sort of thing from happening:

![screen shot 2016-03-11 at 10 45 48 am](https://cloud.githubusercontent.com/assets/696595/13707184/7b1bb672-e776-11e5-9a37-7ff557a9fd4e.png)

If a null User is passed onto the adapter, the logic was such that it'd add on a new user row instead of replacing the current one. This was easily replicable by leaving the app from the Hub and opening it back up into the Hub with the network connection turned off.