### PR TITLE
Fixes crash on network error during CampaignDetailsTask

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignDetailsTask.java
+++ b/app/src/main/java/org/dosomething/letsdothis/tasks/CampaignDetailsTask.java
@@ -15,26 +15,35 @@ import co.touchlab.android.threading.eventbus.EventBusExt;
  */
 public class CampaignDetailsTask extends BaseNetworkErrorHandlerTask
 {
-    private final int                             campaignId;
-    public        Campaign                        campaign;
+    private boolean mHasError;
+    private final int campaignId;
+    public Campaign campaign;
 
-    public CampaignDetailsTask(int campaignId)
-    {
+    public CampaignDetailsTask(int campaignId) {
         this.campaignId = campaignId;
+        this.mHasError = true;
+    }
+
+    public boolean hasError() {
+        return mHasError;
     }
 
     @Override
-    protected void run(Context context) throws Throwable
-    {
+    protected void run(Context context) throws Throwable {
         ResponseCampaignWrapper response = NetworkHelper.getPhoenixAPIService()
                 .campaign(campaignId);
         campaign = ResponseCampaign.getCampaign(response.data);
     }
 
     @Override
-    protected void onComplete(Context context)
-    {
+    protected void onComplete(Context context) {
         EventBusExt.getDefault().post(this);
         super.onComplete(context);
+    }
+
+    @Override
+    protected boolean handleError(Context context, Throwable throwable) {
+        mHasError = true;
+        return true;
     }
 }

--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -372,6 +372,14 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
     @SuppressWarnings("UnusedDeclaration")
     public void onEventMainThread(CampaignDetailsTask task) {
+        // If there's an error, finish this activity and go back to the previous screen
+        // @todo Display an error view instead
+        if (task.hasError()) {
+            Toast.makeText(this, getString(R.string.error_campaign_data), Toast.LENGTH_SHORT).show();
+            finish();
+            return;
+        }
+
         int campaignId = -1;
         boolean isComplete = false;
         boolean isSignedUp = false;
@@ -390,13 +398,15 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
                 isComplete = false;
                 isSignedUp = false;
             }
+
+            // Determines the look and behavior of the call-to-action button
+            task.campaign.showShare = isComplete ? Campaign.UploadShare.SHARE : Campaign.UploadShare.SHOW_OFF;
         }
         else {
-            Toast.makeText(this, "campaign data failed", Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, getString(R.string.error_campaign_data), Toast.LENGTH_SHORT).show();
         }
 
         // Update the view in the adapter
-        task.campaign.showShare = isComplete ? Campaign.UploadShare.SHARE : Campaign.UploadShare.SHOW_OFF;
         adapter.updateCampaign(task.campaign);
 
         sendScreenViewToAnalytics(campaignId, isSignedUp, isComplete);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="error_action_closed_campaign">Sorry! This campaign is now closed.</string>
     <string name="error_action_sms_game">This action is only available on web or SMS</string>
     <string name="error_avatar_upload">There was an error uploading your photo</string>
+    <string name="error_campaign_data">There was an error loading the campaign data</string>
     <string name="error_hub_sync">There was an error syncing your profile</string>
     <string name="error_interest_group_titles">There was an error getting campaign info</string>
     <string name="error_login_phone_email">Must not be empty</string>


### PR DESCRIPTION
When this occurs we'll display a Toast error message and finish out of the CampaignDetailsActivity. In the future, we'll want to display an error view.

Fixes #254 