### PR TITLE
Displays popup error message if user tries to click into a null profile

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/CampaignDetailsActivity.java
@@ -203,7 +203,11 @@ public class CampaignDetailsActivity extends AppCompatActivity implements Campai
 
     @Override
     public void onUserClicked(String id) {
-        startActivity(PublicProfileActivity.getLaunchIntent(this, id));
+        if (id == null || id.isEmpty()) {
+            Toast.makeText(CampaignDetailsActivity.this, R.string.error_public_profile_load, Toast.LENGTH_SHORT).show();
+        } else {
+            startActivity(PublicProfileActivity.getLaunchIntent(this, id));
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
         actions available right now.</string>
     <string name="error_network_main_button">Try Again</string>
     <string name="error_photo_save">There was an error saving the photo. Please try selecting your photo again.</string>
+    <string name="error_public_profile_load">Unable to load this person\'s profile</string>
     <string name="error_registration_email">We need a valid email</string>
     <string name="error_registration_first_name">We need your first name</string>
     <string name="error_registration_password">Your password must be 6+ characters</string>


### PR DESCRIPTION
Some of the photos displayed in a campaign gallery come with a null user profile object in the API response. If we don't handle cases like these, the HubFragment code will default to showing the logged-in user profile.

Relevant Trello card: https://trello.com/c/Diwg0vrf/124-build-1-1-0-profile-redirecting-to-your-profile