### PR TITLE
Handles errors that could come during the sharing of a reportback

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/adapters/HubAdapter.java
@@ -174,9 +174,18 @@ public class HubAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
             // Report back photo
             int lastImageIndex = action.reportback.reportback_items.total - 1;
-            ReportBack rbItem = action.reportback.reportback_items.data[lastImageIndex];
-            Picasso.with(context).load(rbItem.getImagePath()).into(rbViewHolder.image);
-            rbViewHolder.caption.setText(rbItem.caption);
+            String caption = "";
+            if (lastImageIndex >= 0) {
+                ReportBack rbItem = action.reportback.reportback_items.data[lastImageIndex];
+                caption = rbItem.caption;
+
+                Picasso.with(context).load(rbItem.getImagePath()).into(rbViewHolder.image);
+            }
+            else {
+                Picasso.with(context).load(R.drawable.image_error).into(rbViewHolder.image);
+            }
+
+            rbViewHolder.caption.setText(caption);
 
             // Report back campaign name and details
             if (action.reportback != null && action.campaign != null && action.campaign.reportback_info != null) {

--- a/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/fragments/HubFragment.java
@@ -313,7 +313,9 @@ public class HubFragment extends Fragment implements HubAdapter.HubAdapterClickL
     public void onEventMainThread(ProfileReportbackShareTask task) {
         dismissProgressDialogIfDone();
 
-        startActivity(task.getShareIntent());
+        if (! task.hasError()) {
+            startActivity(task.getShareIntent());
+        }
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,7 @@
         actions available right now.</string>
     <string name="error_network_main_button">Try Again</string>
     <string name="error_photo_save">There was an error saving the photo. Please try selecting your photo again.</string>
+    <string name="error_photo_share">There was an error loading your photo</string>
     <string name="error_public_profile_load">Unable to load this person\'s profile</string>
     <string name="error_registration_email">We need a valid email</string>
     <string name="error_registration_first_name">We need your first name</string>


### PR DESCRIPTION
#### What's this PR do?

Fixes a crash that could come from sharing a reportback with invalid data.

We do validation on the data in [ProfileReportbackShareTask](https://github.com/DoSomething/LetsDoThis-Android/compare/master...issue265#diff-d785bc399ae18633eee9c3af7dc5266fR68) and throw a custom error if anything fails. What the user will see is a Toast error message instead of a crash.

We also prevent the Share Intent from starting if there was an error in loading the reportback data.

#### Relevant issues

Fixes #265 