### PR TITLE
Changes the SMS game error message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     </string>
     <string name="done">Done</string>
     <string name="error_action_closed_campaign">Sorry! This campaign is now closed.</string>
-    <string name="error_action_sms_game">This action is only available on web or SMS</string>
+    <string name="error_action_sms_game">This experience can only be done through text messaging. Text APP to 38383 to get started!</string>
     <string name="error_avatar_upload">There was an error uploading your photo</string>
     <string name="error_campaign_data">There was an error loading the campaign data</string>
     <string name="error_hub_sync">There was an error syncing your profile</string>


### PR DESCRIPTION
#### What's this PR do?

"This experience can only be done through text messaging. Text APP to 38383 to get started!"

<img src="https://cloud.githubusercontent.com/assets/696595/14021465/f6bb47c6-f1b1-11e5-927d-d50d500533ac.png" width="256">

This is the message that will now display if you try to signup for an SMS game.

#### Relevant issues?

Closes #264 