### PR TITLE
Hardcodes the sponsor logo for campaign 5769

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,8 +45,8 @@ android {
         applicationId "org.dosomething.letsdothis"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 3
-        versionName "1.1.1"
+        versionCode 4
+        versionName "1.1.2"
         resValue "string", "fabric_api_key", FABRIC_API_KEY
         resValue "string", "facebook_app_id", FACEBOOK_APP_ID_PROD
         resValue "string", "parse_app_id", PARSE_APP_ID

--- a/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaign.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/models/ResponseCampaign.java
@@ -46,6 +46,11 @@ public class ResponseCampaign
         campaign.noun = response.reportback_info.noun;
         campaign.verb = response.reportback_info.verb;
         campaign.sponsorLogo = response.affiliates.getLogo();
+        // Hardcode the sponsor image for campaign 5769
+        // @see https://github.com/DoSomething/LetsDoThis-iOS/issues/998
+        if (campaign.id == 5769) {
+            campaign.sponsorLogo = "https://www.dosomething.org/sites/default/files/SponsorLogo%20NewsCorp.png";
+        }
         return campaign;
     }
 


### PR DESCRIPTION
#### What's this PR do?

- Campaign 5769 needed a hardcoded sponsor logo, so this does that.
- Also updates version code to 4 and name to 1.1.2 for submission update to the Play Store

Behold:

![screen shot 2016-05-02 at 10 46 02 pm](https://cloud.githubusercontent.com/assets/696595/14973754/cdebcb32-10b9-11e6-8a4a-a21fdbaa0513.png)

cc: @aaronschachter @lkpttn 