### PR TITLE
DISCUSSION ONLY: Fixes #278: Image OOM

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="org.dosomething.letsdothis.permission.C2D_MESSAGE" />
 
     <application
+        android:largeHeap="true"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
#### What's this PR do?

Adds `largeHeap="true"` to request more memory for the app, bypassing the OOM exception we're seeing when rendering large bitmaps.

#### Where should the reviewer start?

One-line change to `app/src/main/AndroidManifest.xml`.

#### How should this be manually tested?

Need to test a build against large image loads

#### Any background context you want to provide?

Discussion here: https://github.com/facebook/react-native/issues/6799

#### What are the relevant tickets?

#278 

#### Screenshots (if appropriate)

See issue.

#### Questions:

Need to test the UX as we load many images, and see whether the larger memory heap degrades performance.
