### PR TITLE
Filtered out kudos from report back response; also trapped custom fon…

### DIFF
--- a/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/NetworkHelper.java
@@ -9,7 +9,9 @@ import org.dosomething.letsdothis.BuildConfig;
 import org.dosomething.letsdothis.LDTApplication;
 import org.dosomething.letsdothis.R;
 import org.dosomething.letsdothis.network.deserializers.ResponseCampaignDeserializer;
+import org.dosomething.letsdothis.network.deserializers.ResponseReportBackListDeserializer;
 import org.dosomething.letsdothis.network.models.ResponseCampaign;
+import org.dosomething.letsdothis.network.models.ResponseReportBackList;
 
 import java.util.concurrent.TimeUnit;
 
@@ -91,6 +93,7 @@ public class NetworkHelper
 
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(ResponseCampaign.class, new ResponseCampaignDeserializer<ResponseCampaign>())
+				.registerTypeAdapter(ResponseReportBackList.class, new ResponseReportBackListDeserializer<ResponseReportBackList>())
                 .setDateFormat(JSON_DATE_FORMAT_PHOENIX).create();
         GsonConverter gsonConverter = new GsonConverter(gson);
         return getRequestAdapterBuilder().setConverter(gsonConverter)

--- a/app/src/main/java/org/dosomething/letsdothis/network/deserializers/ResponseReportBackListDeserializer.java
+++ b/app/src/main/java/org/dosomething/letsdothis/network/deserializers/ResponseReportBackListDeserializer.java
@@ -1,0 +1,49 @@
+package org.dosomething.letsdothis.network.deserializers;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+
+/**
+ * Filters incompatible kudos out of the report back response.
+ * @author Eric Ruck
+ */
+public class ResponseReportBackListDeserializer<ResponseReportBackList>
+		implements JsonDeserializer<ResponseReportBackList> {
+	@Override
+	public ResponseReportBackList deserialize(JsonElement json, Type type,
+											  JsonDeserializationContext context)
+			throws JsonParseException {
+		// Check if we need to filter this object
+		// TODO: Kudos need to be updated so they work in the future, for now we're removing them
+		JsonObject jsonObject = json.getAsJsonObject();
+		JsonElement dataElt = jsonObject.get("data");
+		if ((dataElt != null) && dataElt.isJsonArray()) {
+			// Cycle through the array
+			for (JsonElement current : dataElt.getAsJsonArray()) {
+				// Check for kudos
+				JsonElement kudosElt = current.getAsJsonObject().get("kudos");
+				if ((kudosElt == null) || !kudosElt.isJsonObject()) {
+					continue;
+				}
+				JsonObject kudosObj = kudosElt.getAsJsonObject();
+				JsonElement kudosDataElt = kudosObj.get("data");
+				if ((kudosDataElt != null) && (kudosDataElt.isJsonObject())) {
+					// Here's the problem, the current version of Android wants an array
+					kudosObj.remove("data");
+					kudosObj.add("data", new JsonArray());
+				}
+			}
+		}
+
+		// Deserialize the adjusted JSON
+		return new Gson().fromJson(jsonObject, type);
+	}
+}

--- a/app/src/main/java/org/dosomething/letsdothis/ui/views/typeface/CustomTextView.java
+++ b/app/src/main/java/org/dosomething/letsdothis/ui/views/typeface/CustomTextView.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.widget.TextView;
 
 import org.dosomething.letsdothis.R;
@@ -72,7 +73,11 @@ public class CustomTextView extends TextView
 
     public void setTypeface(int typefaceResId)
     {
-        Typeface typeface = TypefaceManager.obtainTypeface(getContext(), typefaceResId);
-        setTypeface(typeface);
+		try {
+			Typeface typeface = TypefaceManager.obtainTypeface(getContext(), typefaceResId);
+			setTypeface(typeface);
+		} catch (Exception excAny) {
+			Log.wtf("CustomTextView", "Failed to set default type face", excAny);
+		}
     }
 }


### PR DESCRIPTION
Create a custom deserialized and installed in the Northstar interface to filter out the kudos coming from the web service, basically replacing it with an empty list that the parser can handle.  This is really a stopgap until a decision is made on how to proceed with kudos, but will reliable keep the app working in the meantime.

Also checked in code to trap custom font exception, it would probably be more convenient for us as well as anyone else forking the code to prevent the font exception.
